### PR TITLE
fix(gcp): add pub visibility and fix borrow errors in gcp_storage.rs

### DIFF
--- a/rustcloud/src/gcp/gcp_apis/storage/gcp_storage.rs
+++ b/rustcloud/src/gcp/gcp_apis/storage/gcp_storage.rs
@@ -3,20 +3,20 @@ use reqwest::header::AUTHORIZATION;
 use serde_json::Value;
 use std::collections::HashMap;
 
-struct GoogleStorage {
+pub struct GoogleStorage {
     client: reqwest::Client,
     base_url: String,
 }
 
 impl GoogleStorage {
-    fn new() -> Self {
+    pub fn new() -> Self {
         GoogleStorage {
             client: reqwest::Client::new(),
             base_url: "https://www.googleapis.com/compute/v1".to_string(),
         }
     }
 
-    async fn create_disk(
+    pub async fn create_disk(
         &self,
         request: HashMap<String, Value>,
     ) -> Result<HashMap<String, Value>, reqwest::Error> {
@@ -97,17 +97,13 @@ impl GoogleStorage {
             }
         }
 
-        option.insert(
-            "Zone",
-            &Value::String(format!("projects/{}/zones/{}", project_id, zone)),
-        );
-        option.insert(
-            "Type",
-            &Value::String(format!(
-                "projects/{}/zones/{}/diskTypes/{}",
-                project_id, zone, disk_type
-            )),
-        );
+        let zone_value = Value::String(format!("projects/{}/zones/{}", project_id, zone));
+        let type_value = Value::String(format!(
+            "projects/{}/zones/{}/diskTypes/{}",
+            project_id, zone, disk_type
+        ));
+        option.insert("Zone", &zone_value);
+        option.insert("Type", &type_value);
 
         let create_disk_json = serde_json::to_string(&option).unwrap();
         let url = format!(
@@ -136,7 +132,7 @@ impl GoogleStorage {
         Ok(response)
     }
 
-    async fn delete_disk(
+    pub async fn delete_disk(
         &self,
         request: HashMap<String, String>,
     ) -> Result<HashMap<String, Value>, reqwest::Error> {
@@ -165,7 +161,7 @@ impl GoogleStorage {
         Ok(response)
     }
 
-    async fn create_snapshot(
+    pub async fn create_snapshot(
         &self,
         request: HashMap<String, Value>,
     ) -> Result<HashMap<String, Value>, reqwest::Error> {


### PR DESCRIPTION

Closes #6 

### Summary

This PR fixes build failures in the GCP storage module caused by visibility issues and borrow checker violations.

---

### Problem

The project failed to compile due to the following errors:

- **E0425 / E0433**  
  `GoogleStorage` was not accessible from test modules because it lacked `pub` visibility.

- **E0716**  
  Temporary `Value::String` values were dropped while still borrowed during `HashMap` insertion.

These errors prevented successful compilation and test execution.

---

### Changes Made

#### Visibility Fixes
- Made `GoogleStorage` struct public  
- Made `new()` constructor public  
- Made `create_disk()` method public  

####  Borrow Checker Fix
- Stored formatted values in local bindings before inserting into the `HashMap`
- Ensured values live long enough to satisfy Rust’s borrow checker

### Testing

- Ran `cargo build` → success  
- Verified tests compile and run correctly  
- No regressions observed  