### PR TITLE
Fix: Properly read and parse GCP storage response bodies

### DIFF
--- a/rustcloud/src/gcp/gcp_apis/storage/gcp_storage.rs
+++ b/rustcloud/src/gcp/gcp_apis/storage/gcp_storage.rs
@@ -125,7 +125,7 @@ impl GoogleStorage {
             .send()
             .await?;
 
-        let mut body = String::new();
+        let body = resp.text().await.unwrap_or_default();
         let mut response: HashMap<String, Value> = HashMap::new();
         response.insert(
             "status".to_string(),
@@ -153,7 +153,7 @@ impl GoogleStorage {
             .send()
             .await?;
 
-        let mut body = String::new();
+        let body = resp.text().await.unwrap_or_default();
 
         let mut response = HashMap::new();
         response.insert(
@@ -247,7 +247,7 @@ impl GoogleStorage {
             .send()
             .await?;
 
-        let mut body = String::new();
+        let body = resp.text().await.unwrap_or_default();
 
         let mut response = HashMap::new();
         response.insert(


### PR DESCRIPTION
### Description
This PR resolves the issue where the HTTP response body was being silently dropped in the GCP storage API module (`gcp_storage.rs`).

Changes made:
- Extracted the response payload using `resp.text().await.unwrap_or_default()` instead of an unused `String::new()` allocation in `create_disk`, `delete_disk`, and `create_snapshot`.
- No new comments were added, matching the codebase style.
- Code was formatted using `cargo fmt`.

Fixes #8

