### PR TITLE
Feat: Add DigitalOcean provider skeleton with compute, dns, network, and storage modules.

### DIFF
--- a/rustcloud/src/digiocean/digiocean_apis/compute/digiocean_droplet.rs
+++ b/rustcloud/src/digiocean/digiocean_apis/compute/digiocean_droplet.rs
@@ -1,0 +1,88 @@
+use reqwest::header::AUTHORIZATION;
+use serde_json::Value;
+use std::collections::HashMap;
+
+pub struct Droplet {
+    client: reqwest::Client,
+    base_url: String,
+    token: String,
+}
+
+impl Droplet {
+    pub fn new(token: String) -> Self {
+        Droplet {
+            client: reqwest::Client::new(),
+            base_url: "https://api.digitalocean.com/v2".to_string(),
+            token,
+        }
+    }
+
+    pub async fn create_droplet(
+        &self,
+        request: HashMap<String, Value>,
+    ) -> Result<HashMap<String, Value>, reqwest::Error> {
+        let url = format!("{}/droplets", self.base_url);
+        let body = serde_json::to_string(&request).unwrap();
+
+        let resp = self
+            .client
+            .post(&url)
+            .header("Content-Type", "application/json")
+            .header(AUTHORIZATION, format!("Bearer {}", self.token))
+            .body(body)
+            .send()
+            .await?;
+
+        let mut response: HashMap<String, Value> = HashMap::new();
+        response.insert(
+            "status".to_string(),
+            Value::Number(resp.status().as_u16().into()),
+        );
+        let body = resp.text().await.unwrap_or_default();
+        response.insert("body".to_string(), Value::String(body));
+        Ok(response)
+    }
+
+    pub async fn delete_droplet(
+        &self,
+        droplet_id: &str,
+    ) -> Result<HashMap<String, Value>, reqwest::Error> {
+        let url = format!("{}/droplets/{}", self.base_url, droplet_id);
+
+        let resp = self
+            .client
+            .delete(&url)
+            .header(AUTHORIZATION, format!("Bearer {}", self.token))
+            .send()
+            .await?;
+
+        let mut response: HashMap<String, Value> = HashMap::new();
+        response.insert(
+            "status".to_string(),
+            Value::Number(resp.status().as_u16().into()),
+        );
+        let body = resp.text().await.unwrap_or_default();
+        response.insert("body".to_string(), Value::String(body));
+        Ok(response)
+    }
+
+    pub async fn list_droplets(&self) -> Result<HashMap<String, Value>, reqwest::Error> {
+        let url = format!("{}/droplets", self.base_url);
+
+        let resp = self
+            .client
+            .get(&url)
+            .header(AUTHORIZATION, format!("Bearer {}", self.token))
+            .send()
+            .await?;
+
+        let mut response: HashMap<String, Value> = HashMap::new();
+        response.insert(
+            "status".to_string(),
+            Value::Number(resp.status().as_u16().into()),
+        );
+        let body = resp.text().await.unwrap_or_default();
+        response.insert("body".to_string(), Value::String(body));
+        Ok(response)
+    }
+}

--- a/rustcloud/src/digiocean/digiocean_apis/compute/mod.rs
+++ b/rustcloud/src/digiocean/digiocean_apis/compute/mod.rs
@@ -1,0 +1,1 @@
+pub mod digiocean_droplet;

--- a/rustcloud/src/digiocean/digiocean_apis/dns/digiocean_dns.rs
+++ b/rustcloud/src/digiocean/digiocean_apis/dns/digiocean_dns.rs
@@ -1,0 +1,68 @@
+use reqwest::header::AUTHORIZATION;
+use serde_json::Value;
+use std::collections::HashMap;
+
+pub struct DigiOceanDns {
+    client: reqwest::Client,
+    base_url: String,
+    token: String,
+}
+
+impl DigiOceanDns {
+    pub fn new(token: String) -> Self {
+        DigiOceanDns {
+            client: reqwest::Client::new(),
+            base_url: "https://api.digitalocean.com/v2".to_string(),
+            token,
+        }
+    }
+
+    pub async fn create_domain(
+        &self,
+        request: HashMap<String, Value>,
+    ) -> Result<HashMap<String, Value>, reqwest::Error> {
+        let url = format!("{}/domains", self.base_url);
+        let body = serde_json::to_string(&request).unwrap();
+
+        let resp = self
+            .client
+            .post(&url)
+            .header("Content-Type", "application/json")
+            .header(AUTHORIZATION, format!("Bearer {}", self.token))
+            .body(body)
+            .send()
+            .await?;
+
+        let mut response: HashMap<String, Value> = HashMap::new();
+        response.insert(
+            "status".to_string(),
+            Value::Number(resp.status().as_u16().into()),
+        );
+        let body = resp.text().await.unwrap_or_default();
+        response.insert("body".to_string(), Value::String(body));
+        Ok(response)
+    }
+
+    pub async fn delete_domain(
+        &self,
+        domain_name: &str,
+    ) -> Result<HashMap<String, Value>, reqwest::Error> {
+        let url = format!("{}/domains/{}", self.base_url, domain_name);
+
+        let resp = self
+            .client
+            .delete(&url)
+            .header(AUTHORIZATION, format!("Bearer {}", self.token))
+            .send()
+            .await?;
+
+        let mut response: HashMap<String, Value> = HashMap::new();
+        response.insert(
+            "status".to_string(),
+            Value::Number(resp.status().as_u16().into()),
+        );
+        let body = resp.text().await.unwrap_or_default();
+        response.insert("body".to_string(), Value::String(body));
+        Ok(response)
+    }
+}

--- a/rustcloud/src/digiocean/digiocean_apis/dns/mod.rs
+++ b/rustcloud/src/digiocean/digiocean_apis/dns/mod.rs
@@ -1,0 +1,1 @@
+pub mod digiocean_dns;

--- a/rustcloud/src/digiocean/digiocean_apis/mod.rs
+++ b/rustcloud/src/digiocean/digiocean_apis/mod.rs
@@ -1,0 +1,4 @@
+pub mod compute;
+pub mod dns;
+pub mod network;
+pub mod storage;

--- a/rustcloud/src/digiocean/digiocean_apis/network/digiocean_loadbalancer.rs
+++ b/rustcloud/src/digiocean/digiocean_apis/network/digiocean_loadbalancer.rs
@@ -1,0 +1,68 @@
+use reqwest::header::AUTHORIZATION;
+use serde_json::Value;
+use std::collections::HashMap;
+
+pub struct DigiOceanLoadBalancer {
+    client: reqwest::Client,
+    base_url: String,
+    token: String,
+}
+
+impl DigiOceanLoadBalancer {
+    pub fn new(token: String) -> Self {
+        DigiOceanLoadBalancer {
+            client: reqwest::Client::new(),
+            base_url: "https://api.digitalocean.com/v2".to_string(),
+            token,
+        }
+    }
+
+    pub async fn create_load_balancer(
+        &self,
+        request: HashMap<String, Value>,
+    ) -> Result<HashMap<String, Value>, reqwest::Error> {
+        let url = format!("{}/load_balancers", self.base_url);
+        let body = serde_json::to_string(&request).unwrap();
+
+        let resp = self
+            .client
+            .post(&url)
+            .header("Content-Type", "application/json")
+            .header(AUTHORIZATION, format!("Bearer {}", self.token))
+            .body(body)
+            .send()
+            .await?;
+
+        let mut response: HashMap<String, Value> = HashMap::new();
+        response.insert(
+            "status".to_string(),
+            Value::Number(resp.status().as_u16().into()),
+        );
+        let body = resp.text().await.unwrap_or_default();
+        response.insert("body".to_string(), Value::String(body));
+        Ok(response)
+    }
+
+    pub async fn delete_load_balancer(
+        &self,
+        lb_id: &str,
+    ) -> Result<HashMap<String, Value>, reqwest::Error> {
+        let url = format!("{}/load_balancers/{}", self.base_url, lb_id);
+
+        let resp = self
+            .client
+            .delete(&url)
+            .header(AUTHORIZATION, format!("Bearer {}", self.token))
+            .send()
+            .await?;
+
+        let mut response: HashMap<String, Value> = HashMap::new();
+        response.insert(
+            "status".to_string(),
+            Value::Number(resp.status().as_u16().into()),
+        );
+        let body = resp.text().await.unwrap_or_default();
+        response.insert("body".to_string(), Value::String(body));
+        Ok(response)
+    }
+}

--- a/rustcloud/src/digiocean/digiocean_apis/network/mod.rs
+++ b/rustcloud/src/digiocean/digiocean_apis/network/mod.rs
@@ -1,0 +1,1 @@
+pub mod digiocean_loadbalancer;

--- a/rustcloud/src/digiocean/digiocean_apis/storage/digiocean_storage.rs
+++ b/rustcloud/src/digiocean/digiocean_apis/storage/digiocean_storage.rs
@@ -1,0 +1,68 @@
+use reqwest::header::AUTHORIZATION;
+use serde_json::Value;
+use std::collections::HashMap;
+
+pub struct DigiOceanStorage {
+    client: reqwest::Client,
+    base_url: String,
+    token: String,
+}
+
+impl DigiOceanStorage {
+    pub fn new(token: String) -> Self {
+        DigiOceanStorage {
+            client: reqwest::Client::new(),
+            base_url: "https://api.digitalocean.com/v2".to_string(),
+            token,
+        }
+    }
+
+    pub async fn create_volume(
+        &self,
+        request: HashMap<String, Value>,
+    ) -> Result<HashMap<String, Value>, reqwest::Error> {
+        let url = format!("{}/volumes", self.base_url);
+        let body = serde_json::to_string(&request).unwrap();
+
+        let resp = self
+            .client
+            .post(&url)
+            .header("Content-Type", "application/json")
+            .header(AUTHORIZATION, format!("Bearer {}", self.token))
+            .body(body)
+            .send()
+            .await?;
+
+        let mut response: HashMap<String, Value> = HashMap::new();
+        response.insert(
+            "status".to_string(),
+            Value::Number(resp.status().as_u16().into()),
+        );
+        let body = resp.text().await.unwrap_or_default();
+        response.insert("body".to_string(), Value::String(body));
+        Ok(response)
+    }
+
+    pub async fn delete_volume(
+        &self,
+        volume_id: &str,
+    ) -> Result<HashMap<String, Value>, reqwest::Error> {
+        let url = format!("{}/volumes/{}", self.base_url, volume_id);
+
+        let resp = self
+            .client
+            .delete(&url)
+            .header(AUTHORIZATION, format!("Bearer {}", self.token))
+            .send()
+            .await?;
+
+        let mut response: HashMap<String, Value> = HashMap::new();
+        response.insert(
+            "status".to_string(),
+            Value::Number(resp.status().as_u16().into()),
+        );
+        let body = resp.text().await.unwrap_or_default();
+        response.insert("body".to_string(), Value::String(body));
+        Ok(response)
+    }
+}

--- a/rustcloud/src/digiocean/digiocean_apis/storage/mod.rs
+++ b/rustcloud/src/digiocean/digiocean_apis/storage/mod.rs
@@ -1,0 +1,1 @@
+pub mod digiocean_storage;

--- a/rustcloud/src/digiocean/mod.rs
+++ b/rustcloud/src/digiocean/mod.rs
@@ -1,0 +1,1 @@
+pub mod digiocean_apis;

--- a/rustcloud/src/main.rs
+++ b/rustcloud/src/main.rs
@@ -56,6 +56,23 @@ pub mod gcp {
     }
     pub mod types;
 }
+
+pub mod digiocean {
+    pub mod digiocean_apis {
+        pub mod compute {
+            pub mod digiocean_droplet;
+        }
+        pub mod dns {
+            pub mod digiocean_dns;
+        }
+        pub mod network {
+            pub mod digiocean_loadbalancer;
+        }
+        pub mod storage {
+            pub mod digiocean_storage;
+        }
+    }
+}
 fn main() {
     println!("Hello, world!");
 }


### PR DESCRIPTION
### Description
This PR adds the initial DigitalOcean cloud provider implementation to address the gap between the README documentation and the actual codebase.

Changes made:
- Added `src/digiocean/` module tree with four service categories: compute (Droplet), dns (Domain), network (LoadBalancer), and storage (Volume).
- Each module follows the identical structure as the existing `src/aws/` and `src/gcp/` providers.
- Registered the `digiocean` module in `src/main.rs`.
- Code was formatted using `cargo fmt`.

Fixes #10 
