### PR TITLE
Fix: Remove duplicated /v1/ path segment in GCE start_node URL

### DIFF
--- a/rustcloud/src/gcp/gcp_apis/compute/gcp_compute_engine.rs
+++ b/rustcloud/src/gcp/gcp_apis/compute/gcp_compute_engine.rs
@@ -191,7 +191,7 @@ impl GCE {
         let zone = request.get("Zone").unwrap();
         let instance = request.get("instance").unwrap();
         let url = format!(
-            "{}/v1/projects/{}/zones/{}/instances/{}/start",
+            "{}/projects/{}/zones/{}/instances/{}/start",
             self.base_url, project_id, zone, instance
         );
 


### PR DESCRIPTION
### Description
This PR fixes a silent runtime bug where `start_node` in `gcp_compute_engine.rs` constructed a malformed Google Cloud API URL, causing all instance start requests to receive a 404 with no helpful error.

The `base_url` already contains `/v1`, so the extra `/v1/` in the format string duplicated the path segment. All other methods in the same struct used the correct format.

Changes made:
- Removed the extra `/v1/` from the `start_node` URL format string on line 194.
- Code formatted using `cargo fmt`.

Fixes #12 
