### PR TITLE
 fix compile-blocking GCP test initializers (E0063)

### DIFF
--- a/rustcloud/src/tests/gcp_bigtable_operations.rs
+++ b/rustcloud/src/tests/gcp_bigtable_operations.rs
@@ -50,13 +50,15 @@ async fn test_create_tables() {
     let parent = "projects/your_project_id/instances/your_instance_id";
     let table_id = "your_table_id";
     let table = Table {
-        // Populate Table struct fields
+        granularity: "MILLIS".to_string(),
+        name: "projects/your_project_id/instances/your_instance_id/tables/your_table_id"
+            .to_string(),
     };
     let initial_splits = vec![InitialSplits {
-            // Populate InitialSplits struct fields
-        }];
+        key: "split-key-1".to_string(),
+    }];
     let cluster_states = ClusterStates {
-        // Populate ClusterStates struct fields
+        replication_state: "READY".to_string(),
     };
 
     let result = client

--- a/rustcloud/src/tests/gcp_kubernetes_operations.rs
+++ b/rustcloud/src/tests/gcp_kubernetes_operations.rs
@@ -1,5 +1,6 @@
 use crate::gcp::gcp_apis::compute::gcp_kubernetes::*;
 use crate::gcp::types::compute::gcp_kubernetes_types::*;
+use std::collections::HashMap;
 use tokio::test;
 
 async fn create_client() -> GCPKubernetesClient {
@@ -13,7 +14,7 @@ async fn test_create_cluster() {
     let request = CreateClusterRequest {
         projectId: "your_project_id".to_string(),
         zone: "your_zone".to_string(),
-        // Add other required fields for CreateClusterRequest here.
+        cluster: HashMap::new(),
     };
 
     let result = client.create_cluster(request).await;
@@ -69,7 +70,7 @@ async fn test_create_node_pool() {
         projectId: "your_project_id".to_string(),
         zone: "your_zone".to_string(),
         clusterId: "your_cluster_id".to_string(),
-        // Add other required fields for CreateNodePoolRequest here.
+        nodePool: HashMap::new(),
     };
 
     let result = client.create_node_pool(request).await;
@@ -128,7 +129,7 @@ async fn test_set_addons_config() {
         projectId: "your_project_id".to_string(),
         zone: "your_zone".to_string(),
         clusterId: "your_cluster_id".to_string(),
-        // Add other required fields for SetAddonsConfigRequest here.
+        addonsConfig: HashMap::new(),
     };
 
     let result = client.set_addons_config(request).await;


### PR DESCRIPTION
### Summary
This PR resolves test compilation failures caused by incomplete struct initializers in the GCP Kubernetes and Bigtable test suites.

---
fixed #14 
### Problem

Running:

cargo test --no-run

failed with E0063 due to missing required struct fields in:

- gcp_kubernetes_operations.rs
- gcp_bigtable_operations.rs

Missing fields:

Kubernetes
- cluster
- nodePool
- addonsConfig

Bigtable
- Table.name
- Table.granularity
- InitialSplits.key
- ClusterStates.replication_state

---

### Changes

gcp_kubernetes_operations.rs
- Added cluster: HashMap::new() to CreateClusterRequest
- Added nodePool: HashMap::new() to CreateNodePoolRequest
- Added addonsConfig: HashMap::new() to SetAddonsConfigRequest
- Added:
  use std::collections::HashMap;

gcp_bigtable_operations.rs
- Added required fields:
  - Table { name, granularity }
  - InitialSplits { key }
  - ClusterStates { replication_state }

---

### Validation

Command executed:

cargo test --no-run -q

Result:
- Compilation succeeds
- E0063 errors resolved
- Existing warnings remain (out of scope)

---

### Scope

- Fixes compilation blockers only
- Does NOT modify runtime behavior
- Does NOT address warnings or deprecations