### PR TITLE
fix: ec2 create-instance error handling: return explicit errors and instance id

### DIFF
--- a/rustcloud/src/aws/aws_apis/compute/aws_ec2.rs
+++ b/rustcloud/src/aws/aws_apis/compute/aws_ec2.rs
@@ -1,11 +1,15 @@
 #![allow(clippy::result_large_err)]
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_ec2::{operation::run_instances::RunInstancesError, types::Tag, Client, Error};
+use aws_sdk_ec2::{types::Tag, Client, Error};
+use std::error::Error as StdError;
 
 // use clap::Parser;
 
-pub async fn create_instance(client: &Client, ami_id: &str) -> Result<(), Error> {
+pub async fn create_instance(
+    client: &Client,
+    ami_id: &str,
+) -> Result<String, Box<dyn StdError>> {
     let run_instances = client
         .run_instances()
         .image_id(ami_id)
@@ -17,25 +21,28 @@ pub async fn create_instance(client: &Client, ami_id: &str) -> Result<(), Error>
 
     match run_instances {
         Ok(run_instances) => {
-            if run_instances.instances().is_empty() {
-                panic!("No instances created.");
-                let instance_id = run_instances.instances()[0].instance_id().unwrap();
-                client
-                    .create_tags()
-                    .resources(instance_id)
-                    .tags(
-                        Tag::builder()
-                            .key("Name")
-                            .value("From SDK Examples")
-                            .build(),
-                    )
-                    .send()
-                    .await
-                    .unwrap();
+            let created_instance = run_instances
+                .instances()
+                .first()
+                .ok_or_else(|| std::io::Error::other("no instances created"))?;
+            let instance_id = created_instance
+                .instance_id()
+                .ok_or_else(|| std::io::Error::other("instance id missing"))?;
 
-                println!("Created {instance_id} and applied tags.",);
-            }
-            Ok(())
+            client
+                .create_tags()
+                .resources(instance_id)
+                .tags(
+                    Tag::builder()
+                        .key("Name")
+                        .value("From SDK Examples")
+                        .build(),
+                )
+                .send()
+                .await?;
+
+            println!("Created {instance_id} and applied tags.");
+            Ok(instance_id.to_string())
         }
         Err(err) => {
             println!("Error: {:?}", err);

--- a/rustcloud/src/tests/aws_ec2_operations.rs
+++ b/rustcloud/src/tests/aws_ec2_operations.rs
@@ -16,6 +16,8 @@ async fn test_create_instance() {
     let ami_id = "ami-0aff18ec83b712f05";
     let result = create_instance(&client, ami_id).await;
     assert!(result.is_ok());
+    let instance_id = result.unwrap();
+    assert!(!instance_id.is_empty());
 }
 
 #[tokio::test]


### PR DESCRIPTION

## Summary

This PR fixes #16   the EC2 creation flow so failures are no longer hidden as success.

`create_instance` now returns an error when no instance is created or when the instance ID is missing, and returns the created instance ID on success.

---

## Problem

In `aws_ec2.rs`, `create_instance` previously returned `Ok(())` even when no instance was created (or no ID was available). This masked real failures and caused callers to assume provisioning succeeded.

---

## Changes

### Function Signature Update

**From**

```rust
Result<(), Error>
```

**To**

```rust
Result<String, Box<dyn std::error::Error>>
```

### Creation Logic Improvements

* Returns `Err("no instances created")` if the response contains no instances.
* Returns `Err("instance id missing")` if the created instance lacks an ID.
* Returns `Ok(instance_id)` only after successful creation and tag application.

### Caller/Test Update

* `aws_ec2_operations.rs` now unwraps the returned ID and asserts it is non-empty.

---

## Files Changed

* `aws_ec2.rs`
* `aws_ec2_operations.rs`

---

## Validation

* Verified the EC2 function no longer reports success on empty results.
* `cargo test --no-run` still fails due to **pre-existing unrelated errors** in GCP modules/tests (out of scope for this PR).

---

## Scope

**In scope**

* EC2 create-instance error propagation
* Return contract improvements

