### PR TITLE
fix(iam): correct create_group path parameter and add user/role management operations

### DIFF
--- a/rustcloud/src/aws/aws_apis/security/aws_iam.rs
+++ b/rustcloud/src/aws/aws_apis/security/aws_iam.rs
@@ -28,13 +28,193 @@ pub async fn attach_group_policy(
 pub async fn create_group(client: &Client, path: String, group_name: String) -> Result<(), Error> {
     let resp = client
         .create_group()
-        .group_name(path)
+        .path(path)
         .group_name(group_name)
         .send()
         .await;
     match resp {
         Ok(result) => {
             println!("creategroup: {:?}", result);
+            Ok(())
+        }
+        Err(e) => {
+            println!("Error : {:?}", e);
+            Err(e.into())
+        }
+    }
+}
+
+pub async fn create_user(
+    client: &Client,
+    user_name: String,
+    path: Option<String>,
+    tags: Option<Vec<aws_sdk_iam::types::Tag>>,
+) -> Result<(), Error> {
+    let mut req = client.create_user().user_name(user_name);
+    if let Some(p) = path {
+        req = req.path(p);
+    }
+    if let Some(t) = tags {
+        req = req.set_tags(Some(t));
+    }
+    let resp = req.send().await;
+    match resp {
+        Ok(result) => {
+            println!("createuser: {:?}", result);
+            Ok(())
+        }
+        Err(e) => {
+            println!("Error : {:?}", e);
+            Err(e.into())
+        }
+    }
+}
+
+pub async fn delete_user(client: &Client, user_name: String) -> Result<(), Error> {
+    let resp = client.delete_user().user_name(user_name).send().await;
+    match resp {
+        Ok(result) => {
+            println!("deleteuser: {:?}", result);
+            Ok(())
+        }
+        Err(e) => {
+            println!("Error : {:?}", e);
+            Err(e.into())
+        }
+    }
+}
+
+pub async fn list_users(
+    client: &Client,
+    path_prefix: Option<String>,
+    marker: Option<String>,
+    max_items: Option<i32>,
+) -> Result<(), Error> {
+    let resp = client
+        .list_users()
+        .set_path_prefix(path_prefix)
+        .set_marker(marker)
+        .set_max_items(max_items)
+        .send()
+        .await;
+    match resp {
+        Ok(result) => {
+            println!("listusers: {:?}", result);
+            Ok(())
+        }
+        Err(e) => {
+            println!("Error : {:?}", e);
+            Err(e.into())
+        }
+    }
+}
+
+pub async fn attach_user_policy(
+    client: &Client,
+    user_name: String,
+    policy_arn: String,
+) -> Result<(), Error> {
+    let resp = client
+        .attach_user_policy()
+        .user_name(user_name)
+        .policy_arn(policy_arn)
+        .send()
+        .await;
+    match resp {
+        Ok(result) => {
+            println!("attachuserpolicy: {:?}", result);
+            Ok(())
+        }
+        Err(e) => {
+            println!("Error : {:?}", e);
+            Err(e.into())
+        }
+    }
+}
+
+pub async fn detach_user_policy(
+    client: &Client,
+    user_name: String,
+    policy_arn: String,
+) -> Result<(), Error> {
+    let resp = client
+        .detach_user_policy()
+        .user_name(user_name)
+        .policy_arn(policy_arn)
+        .send()
+        .await;
+    match resp {
+        Ok(result) => {
+            println!("detachuserpolicy: {:?}", result);
+            Ok(())
+        }
+        Err(e) => {
+            println!("Error : {:?}", e);
+            Err(e.into())
+        }
+    }
+}
+
+pub async fn create_role(
+    client: &Client,
+    role_name: String,
+    assume_role_policy_document: String,
+    path: Option<String>,
+    description: Option<String>,
+) -> Result<(), Error> {
+    let mut req = client
+        .create_role()
+        .role_name(role_name)
+        .assume_role_policy_document(assume_role_policy_document);
+    if let Some(p) = path {
+        req = req.path(p);
+    }
+    if let Some(d) = description {
+        req = req.description(d);
+    }
+    let resp = req.send().await;
+    match resp {
+        Ok(result) => {
+            println!("createrole: {:?}", result);
+            Ok(())
+        }
+        Err(e) => {
+            println!("Error : {:?}", e);
+            Err(e.into())
+        }
+    }
+}
+
+pub async fn delete_role(client: &Client, role_name: String) -> Result<(), Error> {
+    let resp = client.delete_role().role_name(role_name).send().await;
+    match resp {
+        Ok(result) => {
+            println!("deleterole: {:?}", result);
+            Ok(())
+        }
+        Err(e) => {
+            println!("Error : {:?}", e);
+            Err(e.into())
+        }
+    }
+}
+
+pub async fn list_roles(
+    client: &Client,
+    path_prefix: Option<String>,
+    marker: Option<String>,
+    max_items: Option<i32>,
+) -> Result<(), Error> {
+    let resp = client
+        .list_roles()
+        .set_path_prefix(path_prefix)
+        .set_marker(marker)
+        .set_max_items(max_items)
+        .send()
+        .await;
+    match resp {
+        Ok(result) => {
+            println!("listroles: {:?}", result);
             Ok(())
         }
         Err(e) => {

--- a/rustcloud/src/tests/aws_iam_operations.rs
+++ b/rustcloud/src/tests/aws_iam_operations.rs
@@ -62,3 +62,99 @@ async fn test_describe_group() {
     let result = describe(&client, group_name, marker, max_items).await;
     assert!(result.is_ok());
 }
+
+#[tokio::test]
+async fn test_create_user() {
+    let client = create_client().await;
+
+    let user_name = "TestUser".to_string();
+    let path = Some("/".to_string());
+
+    let result = create_user(&client, user_name, path, None).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_delete_user() {
+    let client = create_client().await;
+
+    let user_name = "TestUser".to_string();
+
+    let result = delete_user(&client, user_name).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_list_users() {
+    let client = create_client().await;
+
+    let result = list_users(&client, None, None, Some(50)).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_attach_user_policy() {
+    let client = create_client().await;
+
+    let user_name = "TestUser".to_string();
+    let policy_arn = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess".to_string();
+
+    let result = attach_user_policy(&client, user_name, policy_arn).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_detach_user_policy() {
+    let client = create_client().await;
+
+    let user_name = "TestUser".to_string();
+    let policy_arn = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess".to_string();
+
+    let result = detach_user_policy(&client, user_name, policy_arn).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_create_role() {
+    let client = create_client().await;
+
+    let role_name = "TestRole".to_string();
+    // Minimal trust policy that allows EC2 to assume this role
+    let assume_role_policy_document = r#"{
+        "Version": "2012-10-17",
+        "Statement": [{
+            "Effect": "Allow",
+            "Principal": { "Service": "ec2.amazonaws.com" },
+            "Action": "sts:AssumeRole"
+        }]
+    }"#
+    .to_string();
+
+    let result = create_role(
+        &client,
+        role_name,
+        assume_role_policy_document,
+        Some("/".to_string()),
+        Some("Test role created by RustCloud".to_string()),
+    )
+    .await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_delete_role() {
+    let client = create_client().await;
+
+    let role_name = "TestRole".to_string();
+
+    let result = delete_role(&client, role_name).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_list_roles() {
+    let client = create_client().await;
+
+    let result = list_roles(&client, None, None, Some(50)).await;
+    assert!(result.is_ok());
+}


### PR DESCRIPTION
## Summary

Fixes a silent bug in `create_group` where the `path` parameter was ignored, and adds the missing IAM **user** and **role** management operations which were absent from the module.

Closes #25

---

## Problem

### Bug: `create_group` silently discards the `path` parameter

In `aws_iam.rs`, the builder's `.group_name()` method was mistakenly called twice — once with `path` and once with `group_name`. The second call overwrote the first, causing the `path` parameter to be silently ignored.

```rust
// Before — path is silently lost
client.create_group()
    .group_name(path)
    .group_name(group_name)

// After — path is correctly forwarded
client.create_group()
    .path(path)
    .group_name(group_name)
```

IAM paths are used to organize resources into hierarchical namespaces (e.g. `/engineering/backend/`). Ignoring the parameter results in all groups being created under the root `/`, which can break path-based resource organization and IAM policies scoped to path prefixes.

### Missing IAM Operations

The existing `aws_iam.rs` implementation only supported **group operations**. IAM **user** and **role** management APIs were missing, leaving the module incomplete for real-world IAM workflows.

---

## Changes

### Bug Fix

| File | Change |
|-----|------|
| `src/aws/aws_apis/security/aws_iam.rs` | `create_group`: replaced `.group_name(path)` with `.path(path)` |

### New Functions Added (`aws_iam.rs`)

#### User management

| Function | Description |
|--------|-------------|
| `create_user` | Creates an IAM user with optional `path` and `tags` |
| `delete_user` | Deletes an IAM user by name |
| `list_users` | Lists users with optional `path_prefix` and pagination |
| `attach_user_policy` | Attaches a managed policy ARN to a user |
| `detach_user_policy` | Detaches a managed policy ARN from a user |

#### Role management

| Function | Description |
|--------|-------------|
| `create_role` | Creates a role with a trust policy document, optional `path` and `description` |
| `delete_role` | Deletes a role by name |
| `list_roles` | Lists roles with optional `path_prefix` and pagination |

---

## New Tests Added (`src/tests/aws_iam_operations.rs`)

`test_create_user` · `test_delete_user` · `test_list_users` · `test_attach_user_policy` · `test_detach_user_policy` · `test_create_role` · `test_delete_role` · `test_list_roles`

---

## Testing

```bash
# Type check — no new errors introduced
cargo check

# Run IAM-specific tests (requires AWS credentials)
cargo test aws_iam
```

All new functions follow the existing error-handling patterns and `println!` logging conventions used in the codebase. No existing tests or functionality were modified aside from the `create_group` bug fix.