### PR TITLE
feat(aws-dynamodb): add missing item-level CRUD operations (get_item, put_item, update_item, scan, batch_write_item)

### DIFF
--- a/rustcloud/src/aws/aws_apis/database/aws_dynamodb.rs
+++ b/rustcloud/src/aws/aws_apis/database/aws_dynamodb.rs
@@ -2,16 +2,15 @@
 
 use aws_sdk_dynamodb::{
     types::{
-        AttributeDefinition, AttributeValue, BillingMode, Condition, ConditionalOperator,
-        ExpectedAttributeValue, GlobalSecondaryIndex, KeySchemaElement, LocalSecondaryIndex,
-        OnDemandThroughput, ProvisionedThroughput, ReturnConsumedCapacity,
+        AttributeDefinition, AttributeValue, AttributeValueUpdate, BillingMode, Condition,
+        ConditionalOperator, ExpectedAttributeValue, GlobalSecondaryIndex, KeySchemaElement,
+        LocalSecondaryIndex, OnDemandThroughput, ProvisionedThroughput, ReturnConsumedCapacity,
         ReturnItemCollectionMetrics, ReturnValue, ReturnValuesOnConditionCheckFailure, Select,
-        SseSpecification, StreamSpecification, TableClass, Tag,
+        SseSpecification, StreamSpecification, TableClass, Tag, WriteRequest,
     },
     Client, Error,
 };
 use std::collections::HashMap;
-use tokio;
 
 pub async fn create_table(
     client: &Client,
@@ -112,6 +111,206 @@ pub async fn delete_table(client: &Client, table_name: String) -> Result<(), Err
         Ok(result) => {
             println!("table deleted: {:?}", result);
 
+            Ok(())
+        }
+        Err(e) => {
+            println!("Error : {:?}", e);
+            Err(e.into())
+        }
+    }
+}
+
+pub async fn get_item(
+    client: &Client,
+    table_name: String,
+    key: HashMap<String, AttributeValue>,
+    attributes_to_get: Option<Vec<String>>,
+    consistent_read: Option<bool>,
+    return_consumed_capacity: Option<ReturnConsumedCapacity>,
+    projection_expression: Option<String>,
+    expression_attribute_names: Option<HashMap<String, String>>,
+) -> Result<(), Error> {
+    let resp = client
+        .get_item()
+        .table_name(table_name)
+        .set_key(Some(key))
+        .set_attributes_to_get(attributes_to_get)
+        .set_consistent_read(consistent_read)
+        .set_return_consumed_capacity(return_consumed_capacity)
+        .set_projection_expression(projection_expression)
+        .set_expression_attribute_names(expression_attribute_names)
+        .send()
+        .await;
+
+    match resp {
+        Ok(result) => {
+            println!("item fetched: {:?}", result);
+            Ok(())
+        }
+        Err(e) => {
+            println!("Error : {:?}", e);
+            Err(e.into())
+        }
+    }
+}
+
+pub async fn put_item(
+    client: &Client,
+    table_name: String,
+    item: HashMap<String, AttributeValue>,
+    expected: Option<HashMap<String, ExpectedAttributeValue>>,
+    conditional_operator: Option<ConditionalOperator>,
+    return_values: Option<ReturnValue>,
+    return_consumed_capacity: Option<ReturnConsumedCapacity>,
+    return_item_collection_metrics: Option<ReturnItemCollectionMetrics>,
+    condition_expression: Option<String>,
+    expression_attribute_names: Option<HashMap<String, String>>,
+    expression_attribute_values: Option<HashMap<String, AttributeValue>>,
+    return_values_on_condition_check_failure: Option<ReturnValuesOnConditionCheckFailure>,
+) -> Result<(), Error> {
+    let resp = client
+        .put_item()
+        .table_name(table_name)
+        .set_item(Some(item))
+        .set_expected(expected)
+        .set_conditional_operator(conditional_operator)
+        .set_return_values(return_values)
+        .set_return_consumed_capacity(return_consumed_capacity)
+        .set_return_item_collection_metrics(return_item_collection_metrics)
+        .set_condition_expression(condition_expression)
+        .set_expression_attribute_names(expression_attribute_names)
+        .set_expression_attribute_values(expression_attribute_values)
+        .set_return_values_on_condition_check_failure(return_values_on_condition_check_failure)
+        .send()
+        .await;
+
+    match resp {
+        Ok(result) => {
+            println!("item put: {:?}", result);
+            Ok(())
+        }
+        Err(e) => {
+            println!("Error : {:?}", e);
+            Err(e.into())
+        }
+    }
+}
+
+pub async fn update_item(
+    client: &Client,
+    table_name: String,
+    key: HashMap<String, AttributeValue>,
+    attribute_updates: Option<HashMap<String, AttributeValueUpdate>>,
+    expected: Option<HashMap<String, ExpectedAttributeValue>>,
+    conditional_operator: Option<ConditionalOperator>,
+    return_values: Option<ReturnValue>,
+    return_consumed_capacity: Option<ReturnConsumedCapacity>,
+    return_item_collection_metrics: Option<ReturnItemCollectionMetrics>,
+    update_expression: Option<String>,
+    condition_expression: Option<String>,
+    expression_attribute_names: Option<HashMap<String, String>>,
+    expression_attribute_values: Option<HashMap<String, AttributeValue>>,
+    return_values_on_condition_check_failure: Option<ReturnValuesOnConditionCheckFailure>,
+) -> Result<(), Error> {
+    let resp = client
+        .update_item()
+        .table_name(table_name)
+        .set_key(Some(key))
+        .set_attribute_updates(attribute_updates)
+        .set_expected(expected)
+        .set_conditional_operator(conditional_operator)
+        .set_return_values(return_values)
+        .set_return_consumed_capacity(return_consumed_capacity)
+        .set_return_item_collection_metrics(return_item_collection_metrics)
+        .set_update_expression(update_expression)
+        .set_condition_expression(condition_expression)
+        .set_expression_attribute_names(expression_attribute_names)
+        .set_expression_attribute_values(expression_attribute_values)
+        .set_return_values_on_condition_check_failure(return_values_on_condition_check_failure)
+        .send()
+        .await;
+
+    match resp {
+        Ok(result) => {
+            println!("item updated: {:?}", result);
+            Ok(())
+        }
+        Err(e) => {
+            println!("Error : {:?}", e);
+            Err(e.into())
+        }
+    }
+}
+
+pub async fn scan(
+    client: &Client,
+    table_name: String,
+    index_name: Option<String>,
+    attributes_to_get: Option<Vec<String>>,
+    limit: Option<i32>,
+    consistent_read: Option<bool>,
+    scan_filter: Option<HashMap<String, Condition>>,
+    exclusive_start_key: Option<HashMap<String, AttributeValue>>,
+    return_consumed_capacity: Option<ReturnConsumedCapacity>,
+    total_segments: Option<i32>,
+    segment: Option<i32>,
+    projection_expression: Option<String>,
+    filter_expression: Option<String>,
+    expression_attribute_names: Option<HashMap<String, String>>,
+    expression_attribute_values: Option<HashMap<String, AttributeValue>>,
+    conditional_operator: Option<ConditionalOperator>,
+    select: Option<Select>,
+) -> Result<(), Error> {
+    let resp = client
+        .scan()
+        .table_name(table_name)
+        .set_index_name(index_name)
+        .set_attributes_to_get(attributes_to_get)
+        .set_limit(limit)
+        .set_consistent_read(consistent_read)
+        .set_scan_filter(scan_filter)
+        .set_exclusive_start_key(exclusive_start_key)
+        .set_return_consumed_capacity(return_consumed_capacity)
+        .set_total_segments(total_segments)
+        .set_segment(segment)
+        .set_projection_expression(projection_expression)
+        .set_filter_expression(filter_expression)
+        .set_expression_attribute_names(expression_attribute_names)
+        .set_expression_attribute_values(expression_attribute_values)
+        .set_conditional_operator(conditional_operator)
+        .set_select(select)
+        .send()
+        .await;
+
+    match resp {
+        Ok(result) => {
+            println!("table scanned: {:?}", result);
+            Ok(())
+        }
+        Err(e) => {
+            println!("Error : {:?}", e);
+            Err(e.into())
+        }
+    }
+}
+
+pub async fn batch_write_item(
+    client: &Client,
+    request_items: HashMap<String, Vec<WriteRequest>>,
+    return_consumed_capacity: Option<ReturnConsumedCapacity>,
+    return_item_collection_metrics: Option<ReturnItemCollectionMetrics>,
+) -> Result<(), Error> {
+    let resp = client
+        .batch_write_item()
+        .set_request_items(Some(request_items))
+        .set_return_consumed_capacity(return_consumed_capacity)
+        .set_return_item_collection_metrics(return_item_collection_metrics)
+        .send()
+        .await;
+
+    match resp {
+        Ok(result) => {
+            println!("batch write complete: {:?}", result);
             Ok(())
         }
         Err(e) => {

--- a/rustcloud/src/tests/aws_dynamodb_operations.rs
+++ b/rustcloud/src/tests/aws_dynamodb_operations.rs
@@ -1,10 +1,10 @@
 use crate::aws::aws_apis::database::aws_dynamodb::*;
 use aws_sdk_dynamodb::config::Region;
 use aws_sdk_dynamodb::types::{
-    AttributeDefinition, AttributeValue, BillingMode, ComparisonOperator, Condition,
-    GlobalSecondaryIndex, KeySchemaElement, KeyType, LocalSecondaryIndex, ProvisionedThroughput,
-    ReturnConsumedCapacity, ScalarAttributeType, Select, SseSpecification, StreamSpecification,
-    TableClass,
+    AttributeDefinition, AttributeValue, AttributeValueUpdate, BillingMode, ComparisonOperator,
+    Condition, GlobalSecondaryIndex, KeySchemaElement, KeyType, LocalSecondaryIndex,
+    ProvisionedThroughput, PutRequest, ReturnConsumedCapacity, ReturnValue, ScalarAttributeType,
+    Select, SseSpecification, StreamSpecification, TableClass, WriteRequest,
 };
 use aws_sdk_dynamodb::{Client, Config};
 use std::collections::HashMap;
@@ -131,6 +131,144 @@ async fn test_query() {
         None, // key_condition_expression
         None, // expression_attribute_names
         None, // expression_attribute_values
+    )
+    .await;
+
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_get_item() {
+    let client = create_client().await;
+
+    let table_name = "test-table".to_string();
+    let mut key = HashMap::new();
+    key.insert("id".to_string(), AttributeValue::S("test-id".to_string()));
+
+    let result = get_item(
+        &client,
+        table_name,
+        key,
+        None, // attributes_to_get
+        Some(false), // consistent_read
+        None, // return_consumed_capacity
+        None, // projection_expression
+        None, // expression_attribute_names
+    )
+    .await;
+
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_put_item() {
+    let client = create_client().await;
+
+    let table_name = "test-table".to_string();
+    let mut item = HashMap::new();
+    item.insert("id".to_string(), AttributeValue::S("test-id".to_string()));
+    item.insert("name".to_string(), AttributeValue::S("test-name".to_string()));
+
+    let result = put_item(
+        &client,
+        table_name,
+        item,
+        None, // expected
+        None, // conditional_operator
+        Some(ReturnValue::None),
+        None, // return_consumed_capacity
+        None, // return_item_collection_metrics
+        None, // condition_expression
+        None, // expression_attribute_names
+        None, // expression_attribute_values
+        None, // return_values_on_condition_check_failure
+    )
+    .await;
+
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_update_item() {
+    let client = create_client().await;
+
+    let table_name = "test-table".to_string();
+    let mut key = HashMap::new();
+    key.insert("id".to_string(), AttributeValue::S("test-id".to_string()));
+
+    let result = update_item(
+        &client,
+        table_name,
+        key,
+        None, // attribute_updates
+        None, // expected
+        None, // conditional_operator
+        Some(ReturnValue::AllNew),
+        None, // return_consumed_capacity
+        None, // return_item_collection_metrics
+        Some("SET #n = :val".to_string()), // update_expression
+        None, // condition_expression
+        None, // expression_attribute_names
+        None, // expression_attribute_values
+        None, // return_values_on_condition_check_failure
+    )
+    .await;
+
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_scan() {
+    let client = create_client().await;
+
+    let table_name = "test-table".to_string();
+
+    let result = scan(
+        &client,
+        table_name,
+        None,        // index_name
+        None,        // attributes_to_get
+        Some(100),   // limit
+        Some(false), // consistent_read
+        None,        // scan_filter
+        None,        // exclusive_start_key
+        Some(ReturnConsumedCapacity::Total),
+        None, // total_segments
+        None, // segment
+        None, // projection_expression
+        None, // filter_expression
+        None, // expression_attribute_names
+        None, // expression_attribute_values
+        None, // conditional_operator
+        Some(Select::AllAttributes),
+    )
+    .await;
+
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_batch_write_item() {
+    let client = create_client().await;
+
+    let put_request = PutRequest::builder()
+        .item("id", AttributeValue::S("batch-id-1".to_string()))
+        .item("name", AttributeValue::S("batch-name-1".to_string()))
+        .build()
+        .unwrap();
+
+    let write_request = WriteRequest::builder()
+        .put_request(put_request)
+        .build();
+
+    let mut request_items = HashMap::new();
+    request_items.insert("test-table".to_string(), vec![write_request]);
+
+    let result = batch_write_item(
+        &client,
+        request_items,
+        None, // return_consumed_capacity
+        None, // return_item_collection_metrics
     )
     .await;
 


### PR DESCRIPTION
## Summary

Closes #30

This PR adds the missing item-level CRUD operations to `rustcloud/src/aws/aws_apis/database/aws_dynamodb.rs`.

Previously the DynamoDB module only covered table management (`create_table`, `delete_table`) and limited item access (`delete_item`, `query`), with no way to read, write, or update records — making the module unusable for any real application workload.

## What Was Added

| Function | AWS API | Description |
|---|---|---|
| `get_item` | `GetItem` | Fetch a single record by primary key, with optional consistent read and projection |
| `put_item` | `PutItem` | Insert or replace a record with full condition expression support |
| `update_item` | `UpdateItem` | Update specific attributes; supports both legacy `attribute_updates` and modern `update_expression` |
| `scan` | `Scan` | Full table scan with filter expressions, pagination, and parallel segment support |
| `batch_write_item` | `BatchWriteItem` | Bulk insert/delete across one or more tables in a single API call |

Also added corresponding tests for all five operations in:
- `rustcloud/src/tests/aws_dynamodb_operations.rs`

## Implementation Notes

- No new dependencies required — `aws-sdk-dynamodb` was already in `Cargo.toml`
- All functions follow the existing builder pattern used throughout the module
- `update_item` exposes both `attribute_updates` (legacy) and `update_expression` (modern) to match full AWS API parity
- `scan` exposes `total_segments` and `segment` for parallel scan workloads
- Removed a pre-existing unused `use tokio;` import from the source file

## Validation

- No diagnostics in modified files
- Pre-existing unrelated compile errors exist in `src/tests/gcp_storage_operations.rs` and `src/gcp/gcp_apis/storage/gcp_storage.rs` — not introduced by this PR