### PR TITLE
fix: missing struct fields & borrow-after-move in GCP tests

### DIFF
--- a/rustcloud/src/gcp/gcp_apis/storage/gcp_storage.rs
+++ b/rustcloud/src/gcp/gcp_apis/storage/gcp_storage.rs
@@ -16,7 +16,7 @@ impl GoogleStorage {
         }
     }
 
-    async fn create_disk(
+    pub async fn create_disk(
         &self,
         request: HashMap<String, Value>,
     ) -> Result<HashMap<String, Value>, reqwest::Error> {
@@ -121,18 +121,19 @@ impl GoogleStorage {
             .send()
             .await?;
 
+        let status = resp.status().as_u16();
         let body = resp.text().await.unwrap_or_default();
         let mut response: HashMap<String, Value> = HashMap::new();
         response.insert(
             "status".to_string(),
-            Value::Number(resp.status().as_u16().into()),
+            Value::Number(status.into()),
         );
         response.insert("body".to_string(), Value::String(body));
 
         Ok(response)
     }
 
-    async fn delete_disk(
+    pub async fn delete_disk(
         &self,
         request: HashMap<String, String>,
     ) -> Result<HashMap<String, Value>, reqwest::Error> {
@@ -149,19 +150,20 @@ impl GoogleStorage {
             .send()
             .await?;
 
+        let status = resp.status().as_u16();
         let body = resp.text().await.unwrap_or_default();
 
         let mut response = HashMap::new();
         response.insert(
             "status".to_string(),
-            Value::Number(resp.status().as_u16().into()),
+            Value::Number(status.into()),
         );
         response.insert("body".to_string(), Value::String(body));
 
         Ok(response)
     }
 
-    async fn create_snapshot(
+    pub async fn create_snapshot(
         &self,
         request: HashMap<String, Value>,
     ) -> Result<HashMap<String, Value>, reqwest::Error> {
@@ -243,12 +245,13 @@ impl GoogleStorage {
             .send()
             .await?;
 
+        let status = resp.status().as_u16();
         let body = resp.text().await.unwrap_or_default();
 
         let mut response = HashMap::new();
         response.insert(
             "status".to_string(),
-            Value::Number(resp.status().as_u16().into()),
+            Value::Number(status.into()),
         );
         response.insert("body".to_string(), Value::String(body));
 

--- a/rustcloud/src/tests/gcp_bigtable_operations.rs
+++ b/rustcloud/src/tests/gcp_bigtable_operations.rs
@@ -50,13 +50,14 @@ async fn test_create_tables() {
     let parent = "projects/your_project_id/instances/your_instance_id";
     let table_id = "your_table_id";
     let table = Table {
-        // Populate Table struct fields
+        granularity: "MILLIS".to_string(),
+        name: "your_table_name".to_string(),
     };
     let initial_splits = vec![InitialSplits {
-            // Populate InitialSplits struct fields
-        }];
+        key: "split_key".to_string(),
+    }];
     let cluster_states = ClusterStates {
-        // Populate ClusterStates struct fields
+        replication_state: "READY".to_string(),
     };
 
     let result = client


### PR DESCRIPTION

Fixes #14

## Problem
`cargo test --no-run` was failing with E0063 compilation errors in GCP test modules.  
The issues were caused by:
- Struct initializers missing required fields
- Borrow-after-move errors in `gcp_storage.rs` where `resp.text()` consumed the response before `resp.status()` was accessed
- Some storage methods being private, preventing test modules from accessing them

## Changes
- Added missing required fields:
  - `granularity`, `name` in `Table`
  - `key` in `InitialSplits`
  - `replication_state` in `ClusterStates`
- Fixed borrow-after-move errors by storing `resp.status().as_u16()` in a local variable before calling `resp.text()`
- Made `create_disk`, `delete_disk`, and `create_snapshot` methods `pub` so they can be accessed by test modules

## Files Changed
- `gcp_bigtable_operations.rs`
- `gcp_storage.rs`