### PR TITLE
fix: read response status before consuming body in GCP storage handlers

### DIFF
--- a/rustcloud/src/aws/aws_apis/compute/aws_ec2.rs
+++ b/rustcloud/src/aws/aws_apis/compute/aws_ec2.rs
@@ -24,8 +24,10 @@ pub async fn create_instance(
                     "No instances were created",
                 )));
             }
-            let instance_id =
-                run_instances.instances()[0].instance_id().unwrap().to_string();
+            let instance_id = run_instances.instances()[0]
+                .instance_id()
+                .unwrap()
+                .to_string();
             if let Err(e) = client
                 .create_tags()
                 .resources(&instance_id)

--- a/rustcloud/src/azure/azure_apis/auth/azure_auth.rs
+++ b/rustcloud/src/azure/azure_apis/auth/azure_auth.rs
@@ -6,25 +6,21 @@ use std::env;
 type HmacSha256 = Hmac<Sha256>;
 pub struct AzureAuth;
 
-
 impl AzureAuth {
     pub fn generate_headers(method: &str, account: &str, resource: &str) -> (String, String) {
-
         let key = env::var("AZURE_STORAGE_KEY").expect("AZURE_STORAGE_KEY not set");
-        
+
         let date = Utc::now().format("%a, %d %b %Y %H:%M:%S GMT").to_string();
-        
+
         let mut path = resource.to_string();
-        
+
         let mut query = String::new();
 
         if let Some(pos) = resource.find('?') {
             path = resource[..pos].to_string();
-        
+
             query = resource[pos + 1..].to_string();
         }
-
-
 
         let canonicalized_resource = if query.is_empty() {
             format!("/{}{}", account, path)
@@ -42,22 +38,18 @@ impl AzureAuth {
         let string_to_sign = format!(
             "{}\n\n\n\n\n\n\n\n\n\n\n\nx-ms-date:{}\nx-ms-version:2020-10-02\n{}",
             method, date, canonicalized_resource
-      
         );
 
         let decoded_key = general_purpose::STANDARD.decode(key).unwrap();
-        
 
         let mut mac = HmacSha256::new_from_slice(&decoded_key).unwrap();
-        
+
         mac.update(string_to_sign.as_bytes());
-        
+
         let signature = general_purpose::STANDARD.encode(mac.finalize().into_bytes());
 
-        
         let auth_header = format!("SharedKey {}:{}", account, signature);
 
         (auth_header, date)
-
     }
 }

--- a/rustcloud/src/azure/azure_apis/storage/azure_blob.rs
+++ b/rustcloud/src/azure/azure_apis/storage/azure_blob.rs
@@ -3,7 +3,6 @@ use std::error::Error;
 
 use crate::azure::azure_apis::auth::azure_auth::AzureAuth;
 
-
 pub struct AzureBlobClient {
     client: Client,
     account: String,
@@ -12,9 +11,7 @@ pub struct AzureBlobClient {
 
 impl AzureBlobClient {
     pub fn new(account: String) -> Self {
-
         let base_url = format!("https://{}.blob.core.windows.net", account);
-
 
         AzureBlobClient {
             client: Client::new(),
@@ -24,14 +21,12 @@ impl AzureBlobClient {
     }
 
     pub async fn list_containers(&self) -> Result<String, Box<dyn Error>> {
-        
         let resource = "/?comp=list";
-        
+
         let (auth, date) = AzureAuth::generate_headers("GET", &self.account, resource);
-        
 
         let url = format!("{}?comp=list", self.base_url);
-        
+
         let response = self
             .client
             .get(&url)
@@ -40,26 +35,23 @@ impl AzureBlobClient {
             .header("Authorization", auth)
             .send()
             .await?;
-        
+
         let status = response.status();
         let body = response.text().await?;
-        
+
         if !status.is_success() {
             return Err(format!("Azure error: {}", body).into());
         }
-        
-        Ok(body)
 
+        Ok(body)
     }
 
-    
     pub async fn create_container(&self, container: &str) -> Result<String, Box<dyn Error>> {
-        
         let resource = format!("/{}?restype=container", container);
-        
+
         let (auth, date) = AzureAuth::generate_headers("PUT", &self.account, &resource);
         let url = format!("{}/{}?restype=container", self.base_url, container);
-        
+
         let response = self
             .client
             .put(&url)
@@ -69,27 +61,25 @@ impl AzureBlobClient {
             .header("Authorization", auth)
             .send()
             .await?;
-        
+
         let status = response.status();
-        
+
         let body = response.text().await?;
-        
+
         if !status.is_success() {
             return Err(format!("Azure error: {}", body).into());
         }
-        
+
         Ok(body)
     }
-    
-    
+
     pub async fn delete_container(&self, container: &str) -> Result<String, Box<dyn Error>> {
-        
         let resource = format!("/{}?restype=container", container);
-        
+
         let (auth, date) = AzureAuth::generate_headers("DELETE", &self.account, &resource);
-        
+
         let url = format!("{}/{}?restype=container", self.base_url, container);
-        
+
         let response = self
             .client
             .delete(&url)
@@ -98,15 +88,15 @@ impl AzureBlobClient {
             .header("Authorization", auth)
             .send()
             .await?;
-        
+
         let status = response.status();
-        
+
         let body = response.text().await?;
-        
+
         if !status.is_success() {
             return Err(format!("Azure error: {}", body).into());
         }
-        
+
         Ok(body)
     }
 }

--- a/rustcloud/src/gcp/gcp_apis/database/gcp_bigquery.rs
+++ b/rustcloud/src/gcp/gcp_apis/database/gcp_bigquery.rs
@@ -72,9 +72,7 @@ impl BigQuery {
         Ok(json!({ "status": status.as_u16(), "body": body }))
     }
 
-    pub async fn list_datasets(
-        &self,
-    ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
+    pub async fn list_datasets(&self) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
         let url = format!("{}/projects/{}/datasets", self.base_url, self.project_id);
 
         let token = retrieve_token().await?;

--- a/rustcloud/src/gcp/gcp_apis/storage/gcp_storage.rs
+++ b/rustcloud/src/gcp/gcp_apis/storage/gcp_storage.rs
@@ -121,11 +121,12 @@ impl GoogleStorage {
             .send()
             .await?;
 
+        let status = resp.status().as_u16();
         let body = resp.text().await.unwrap_or_default();
         let mut response: HashMap<String, Value> = HashMap::new();
         response.insert(
             "status".to_string(),
-            Value::Number(resp.status().as_u16().into()),
+            Value::Number(status.into()),
         );
         response.insert("body".to_string(), Value::String(body));
 
@@ -149,12 +150,13 @@ impl GoogleStorage {
             .send()
             .await?;
 
+        let status = resp.status().as_u16();
         let body = resp.text().await.unwrap_or_default();
 
         let mut response = HashMap::new();
         response.insert(
             "status".to_string(),
-            Value::Number(resp.status().as_u16().into()),
+            Value::Number(status.into()),
         );
         response.insert("body".to_string(), Value::String(body));
 
@@ -243,12 +245,13 @@ impl GoogleStorage {
             .send()
             .await?;
 
+        let status = resp.status().as_u16();
         let body = resp.text().await.unwrap_or_default();
 
         let mut response = HashMap::new();
         response.insert(
             "status".to_string(),
-            Value::Number(resp.status().as_u16().into()),
+            Value::Number(status.into()),
         );
         response.insert("body".to_string(), Value::String(body));
 

--- a/rustcloud/src/gcp/gcp_apis/storage/gcp_storage.rs
+++ b/rustcloud/src/gcp/gcp_apis/storage/gcp_storage.rs
@@ -124,10 +124,7 @@ impl GoogleStorage {
         let status = resp.status().as_u16();
         let body = resp.text().await.unwrap_or_default();
         let mut response: HashMap<String, Value> = HashMap::new();
-        response.insert(
-            "status".to_string(),
-            Value::Number(status.into()),
-        );
+        response.insert("status".to_string(), Value::Number(status.into()));
         response.insert("body".to_string(), Value::String(body));
 
         Ok(response)
@@ -154,10 +151,7 @@ impl GoogleStorage {
         let body = resp.text().await.unwrap_or_default();
 
         let mut response = HashMap::new();
-        response.insert(
-            "status".to_string(),
-            Value::Number(status.into()),
-        );
+        response.insert("status".to_string(), Value::Number(status.into()));
         response.insert("body".to_string(), Value::String(body));
 
         Ok(response)
@@ -249,10 +243,7 @@ impl GoogleStorage {
         let body = resp.text().await.unwrap_or_default();
 
         let mut response = HashMap::new();
-        response.insert(
-            "status".to_string(),
-            Value::Number(status.into()),
-        );
+        response.insert("status".to_string(), Value::Number(status.into()));
         response.insert("body".to_string(), Value::String(body));
 
         Ok(response)

--- a/rustcloud/src/gcp/types/database/mod.rs
+++ b/rustcloud/src/gcp/types/database/mod.rs
@@ -1,2 +1,2 @@
-pub mod gcp_bigtable_types;
 pub mod gcp_bigquery_types;
+pub mod gcp_bigtable_types;

--- a/rustcloud/src/main.rs
+++ b/rustcloud/src/main.rs
@@ -1,5 +1,5 @@
-mod tests;
 pub mod errors;
+mod tests;
 pub mod types {
     pub mod llm;
 }
@@ -7,12 +7,12 @@ pub mod traits {
     pub mod llm_provider;
     pub mod token_provider;
 }
-pub mod azure{
-    pub mod azure_apis{
-        pub mod auth{
+pub mod azure {
+    pub mod azure_apis {
+        pub mod auth {
             pub mod azure_auth;
         }
-        pub mod storage{
+        pub mod storage {
             pub mod azure_blob;
         }
     }
@@ -59,8 +59,8 @@ pub mod gcp {
             pub mod gcp_kubernetes;
         }
         pub mod database {
-            pub mod gcp_bigtable;
             pub mod gcp_bigquery;
+            pub mod gcp_bigtable;
         }
         pub mod network {
             pub mod gcp_dns;

--- a/rustcloud/src/tests/aws_bucket_operations.rs
+++ b/rustcloud/src/tests/aws_bucket_operations.rs
@@ -21,10 +21,21 @@ async fn create_test_bucket(client: &Client, bucket: &str) {
     let cfg = CreateBucketConfiguration::builder()
         .location_constraint(aws_sdk_s3::types::BucketLocationConstraint::UsWest2)
         .build();
-    create_bucket(client, BucketCannedAcl::PublicRead, bucket.to_string(), cfg,
-        None, None, None, None, None, None, None)
-        .await
-        .expect("Failed to create test bucket");
+    create_bucket(
+        client,
+        BucketCannedAcl::PublicRead,
+        bucket.to_string(),
+        cfg,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    .await
+    .expect("Failed to create test bucket");
 }
 
 #[tokio::test]
@@ -36,9 +47,19 @@ async fn test_create_bucket() {
         .build();
 
     let result = create_bucket(
-        &client, BucketCannedAcl::PublicRead, bucket.clone(), cfg,
-        None, None, None, None, None, None, None,
-    ).await;
+        &client,
+        BucketCannedAcl::PublicRead,
+        bucket.clone(),
+        cfg,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    .await;
 
     assert!(result.is_ok());
     delete(&client, bucket, None).await.ok();
@@ -61,9 +82,15 @@ async fn test_delete_object() {
     create_test_bucket(&client, bucket).await;
 
     let result = delete_object(
-        &client, bucket.to_string(), "test-object".to_string(),
-        None, None, None, None,
-    ).await;
+        &client,
+        bucket.to_string(),
+        "test-object".to_string(),
+        None,
+        None,
+        None,
+        None,
+    )
+    .await;
 
     assert!(result.is_ok());
     delete(&client, bucket.to_string(), None).await.ok();
@@ -116,8 +143,18 @@ async fn test_list_objects_v2() {
     let client = create_client().await;
     let bucket = "test-bucket".to_string();
 
-    let result = list_objects_v2(&client, bucket, None, None, Some(100), None, None, None, None)
-        .await;
+    let result = list_objects_v2(
+        &client,
+        bucket,
+        None,
+        None,
+        Some(100),
+        None,
+        None,
+        None,
+        None,
+    )
+    .await;
 
     assert!(result.is_ok());
 }

--- a/rustcloud/src/tests/aws_dynamodb_operations.rs
+++ b/rustcloud/src/tests/aws_dynamodb_operations.rs
@@ -149,11 +149,11 @@ async fn test_get_item() {
         &client,
         table_name,
         key,
-        None, // attributes_to_get
+        None,        // attributes_to_get
         Some(false), // consistent_read
-        None, // return_consumed_capacity
-        None, // projection_expression
-        None, // expression_attribute_names
+        None,        // return_consumed_capacity
+        None,        // projection_expression
+        None,        // expression_attribute_names
     )
     .await;
 
@@ -167,7 +167,10 @@ async fn test_put_item() {
     let table_name = "test-table".to_string();
     let mut item = HashMap::new();
     item.insert("id".to_string(), AttributeValue::S("test-id".to_string()));
-    item.insert("name".to_string(), AttributeValue::S("test-name".to_string()));
+    item.insert(
+        "name".to_string(),
+        AttributeValue::S("test-name".to_string()),
+    );
 
     let result = put_item(
         &client,
@@ -204,13 +207,13 @@ async fn test_update_item() {
         None, // expected
         None, // conditional_operator
         Some(ReturnValue::AllNew),
-        None, // return_consumed_capacity
-        None, // return_item_collection_metrics
+        None,                              // return_consumed_capacity
+        None,                              // return_item_collection_metrics
         Some("SET #n = :val".to_string()), // update_expression
-        None, // condition_expression
-        None, // expression_attribute_names
-        None, // expression_attribute_values
-        None, // return_values_on_condition_check_failure
+        None,                              // condition_expression
+        None,                              // expression_attribute_names
+        None,                              // expression_attribute_values
+        None,                              // return_values_on_condition_check_failure
     )
     .await;
 
@@ -257,9 +260,7 @@ async fn test_batch_write_item() {
         .build()
         .unwrap();
 
-    let write_request = WriteRequest::builder()
-        .put_request(put_request)
-        .build();
+    let write_request = WriteRequest::builder().put_request(put_request).build();
 
     let mut request_items = HashMap::new();
     request_items.insert("test-table".to_string(), vec![write_request]);

--- a/rustcloud/src/tests/aws_ec2_operations.rs
+++ b/rustcloud/src/tests/aws_ec2_operations.rs
@@ -98,7 +98,9 @@ async fn test_start_instance() {
     let client = create_client().await;
     let instance_id = create_test_instance(&client).await;
     wait_for_instance_state(&client, &instance_id, "running").await;
-    stop_instance(&client, &instance_id).await.expect("stop_instance failed");
+    stop_instance(&client, &instance_id)
+        .await
+        .expect("stop_instance failed");
     wait_for_instance_state(&client, &instance_id, "stopped").await;
     let result = start_instance(&client, &instance_id).await;
     cleanup_test_instance(&client, &instance_id).await;

--- a/rustcloud/src/tests/azure_blob_operations.rs
+++ b/rustcloud/src/tests/azure_blob_operations.rs
@@ -1,6 +1,5 @@
 use crate::azure::azure_apis::storage::azure_blob::AzureBlobClient;
 
-
 async fn create_client() -> AzureBlobClient {
     let account = std::env::var("AZURE_STORAGE_ACCOUNT").expect("AZURE_STORAGE_ACCOUNT not set");
 
@@ -9,7 +8,6 @@ async fn create_client() -> AzureBlobClient {
 
 #[tokio::test]
 async fn test_list_containers() {
-
     let client = create_client().await;
 
     let result = client.list_containers().await;
@@ -27,7 +25,6 @@ async fn test_list_containers() {
 
 #[tokio::test]
 async fn test_create_container() {
-    
     let client = create_client().await;
 
     let container = "test-container";
@@ -37,10 +34,8 @@ async fn test_create_container() {
     assert!(result.is_ok(), "{:?}", result);
 }
 
-
 #[tokio::test]
 async fn test_delete_container() {
-
     let client = create_client().await;
 
     let container = "test-container";

--- a/rustcloud/src/tests/gcp_bigquery_operations.rs
+++ b/rustcloud/src/tests/gcp_bigquery_operations.rs
@@ -57,7 +57,10 @@ async fn test_create_table() {
     let result = client
         .create_table("test_create_table_ds", "test_tbl", fields)
         .await;
-    client.delete_dataset("test_create_table_ds", true).await.ok();
+    client
+        .delete_dataset("test_create_table_ds", true)
+        .await
+        .ok();
     assert!(result.is_ok());
     let response = result.unwrap();
     assert_eq!(response["status"], 200);
@@ -67,10 +70,21 @@ async fn test_create_table() {
 async fn test_delete_table() {
     let client = create_client().await;
     client.create_dataset("test_delete_table_ds").await.ok();
-    let fields = vec![TableField { name: "id".to_string(), field_type: "INTEGER".to_string() }];
-    client.create_table("test_delete_table_ds", "test_tbl", fields).await.ok();
-    let result = client.delete_table("test_delete_table_ds", "test_tbl").await;
-    client.delete_dataset("test_delete_table_ds", true).await.ok();
+    let fields = vec![TableField {
+        name: "id".to_string(),
+        field_type: "INTEGER".to_string(),
+    }];
+    client
+        .create_table("test_delete_table_ds", "test_tbl", fields)
+        .await
+        .ok();
+    let result = client
+        .delete_table("test_delete_table_ds", "test_tbl")
+        .await;
+    client
+        .delete_dataset("test_delete_table_ds", true)
+        .await
+        .ok();
     assert!(result.is_ok());
     let response = result.unwrap();
     assert_eq!(response["status"], 204);
@@ -81,7 +95,10 @@ async fn test_list_tables() {
     let client = create_client().await;
     client.create_dataset("test_list_tables_ds").await.ok();
     let result = client.list_tables("test_list_tables_ds").await;
-    client.delete_dataset("test_list_tables_ds", true).await.ok();
+    client
+        .delete_dataset("test_list_tables_ds", true)
+        .await
+        .ok();
     assert!(result.is_ok());
     let response = result.unwrap();
     assert_eq!(response["status"], 200);

--- a/rustcloud/src/tests/mod.rs
+++ b/rustcloud/src/tests/mod.rs
@@ -1,4 +1,3 @@
-mod azure_blob_operations;
 mod aws_archival_operations;
 mod aws_block_operations;
 mod aws_bucket_operations;
@@ -11,9 +10,10 @@ mod aws_iam_operations;
 mod aws_kms_operations;
 mod aws_loadbalancer_operations;
 mod aws_monitoring_operations;
+mod azure_blob_operations;
 mod gcp_automl_operations;
-mod gcp_bigtable_operations;
 mod gcp_bigquery_operations;
+mod gcp_bigtable_operations;
 mod gcp_compute_operations;
 mod gcp_dns_operations;
 mod gcp_kubernetes_operations;


### PR DESCRIPTION
**Summary**
- Fixes an `E0382` compile error where `resp.text()` consumes `resp` before `resp.status()` is read.

**Problem**
- `Response::text()` takes ownership of the response. If code calls `resp.text().await` before `resp.status()`, subsequent access to `resp` causes `error[E0382]: borrow of moved value`.

**Changes**
- Edit `src/gcp/gcp_apis/storage/gcp_storage.rs` to read status before body.

code change:
- Before (problematic):
  - `let body = resp.text().await.unwrap_or_default();`
  - `let status = resp.status().as_u16();`
- After (fixed):
  - `let status = resp.status().as_u16();`
  - `let body = resp.text().await.unwrap_or_default();`

**Files**
- Modified: src/gcp/gcp_apis/storage/gcp_storage.rs