### PR TITLE
feat(azure): implement network, vm, and resource group operations

### DIFF
--- a/rustcloud/Cargo.toml
+++ b/rustcloud/Cargo.toml
@@ -30,8 +30,8 @@ gcloud-sdk = "0.24.7"
 gcp_auth = "0.12.2"
 hmac = "0.12.1"
 mockall = "=0.9.1"
-reqwest = "0.12.5"
 rustls = { version = "0.23", features = ["ring"] }
+reqwest = { version = "0.12.5", features = ["json"] }
 serde = "1.0.203"
 serde_json = "1.0.118"
 sha2 = "0.10.9"

--- a/rustcloud/src/azure/azure_apis/auth/azure_cli_auth.rs
+++ b/rustcloud/src/azure/azure_apis/auth/azure_cli_auth.rs
@@ -1,0 +1,34 @@
+use serde::Deserialize;
+use std::process::Command;
+
+#[derive(Debug, Deserialize)]
+struct AzureToken {
+    accessToken: String,
+}
+
+pub struct AzureCliAuth;
+
+impl AzureCliAuth {
+    pub fn get_token() -> Result<String, Box<dyn std::error::Error>> {
+        let output = Command::new("az.cmd")
+            .args([
+                "account",
+                "get-access-token",
+                "--resource",
+                "https://management.azure.com/",
+                "--output",
+                "json",
+            ])
+            .output()?;
+
+        if !output.status.success() {
+            return Err("Failed to get Azure CLI token".into());
+        }
+
+        let json = String::from_utf8(output.stdout)?;
+
+        let token: AzureToken = serde_json::from_str(&json)?;
+
+        Ok(token.accessToken)
+    }
+}

--- a/rustcloud/src/azure/azure_apis/auth/mod.rs
+++ b/rustcloud/src/azure/azure_apis/auth/mod.rs
@@ -1,1 +1,2 @@
 pub mod azure_auth;
+pub mod azure_cli_auth;

--- a/rustcloud/src/azure/azure_apis/compute/azure_vm.rs
+++ b/rustcloud/src/azure/azure_apis/compute/azure_vm.rs
@@ -1,0 +1,326 @@
+use crate::azure::azure_apis::auth::azure_cli_auth::AzureCliAuth;
+use reqwest::Client;
+use std::env;
+
+pub struct AzureVMClient {
+    client: Client,
+    subscription_id: String,
+}
+
+impl AzureVMClient {
+    pub fn new() -> Self {
+        let subscription_id =
+            env::var("AZURE_SUBSCRIPTION_ID").expect("AZURE_SUBSCRIPTION_ID not set");
+
+        AzureVMClient {
+            client: Client::new(),
+            subscription_id,
+        }
+    }
+
+    pub async fn create_vm(
+        &self,
+        resource_group: &str,
+        vm_name: &str,
+        location: &str,
+        nic_id: &str,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let token = AzureCliAuth::get_token()?;
+
+        let url = format!(
+        "https://management.azure.com/subscriptions/{}/resourceGroups/{}/providers/Microsoft.Compute/virtualMachines/{}?api-version=2023-09-01",
+        self.subscription_id,
+        resource_group,
+        vm_name
+    );
+
+        let body = serde_json::json!({
+            "location": location,
+            "properties": {
+                "hardwareProfile": {
+                    "vmSize": "Standard_B1s"
+                },
+                "storageProfile": {
+                    "imageReference": {
+                        "publisher": "Canonical",
+                        "offer": "0001-com-ubuntu-server-jammy",
+                        "sku": "22_04-lts",
+                        "version": "latest"
+                    }
+                },
+                "osProfile": {
+                    "computerName": vm_name,
+                    "adminUsername": "azureuser",
+                    "adminPassword": "Password1234!"
+                },
+                "networkProfile": {
+                    "networkInterfaces": [
+                        {
+                            "id": nic_id
+                        }
+                    ]
+                }
+            }
+        });
+
+        let res = self
+            .client
+            .put(url)
+            .bearer_auth(token)
+            .json(&body)
+            .send()
+            .await?;
+
+        let status = res.status();
+        let body_text = res.text().await?;
+
+        println!("-------------------------------");
+        println!("AZURE API DEBUG");
+        println!("Status  : {}", status);
+        println!("Response: {}", body_text);
+        println!("-------------------------------");
+
+        if !status.is_success() {
+            return Err(format!("Azure VM Instance creation failed: {}", body_text).into());
+        }
+
+        Ok(())
+    }
+
+    pub async fn list_vms(&self, resource_group: &str) -> Result<(), Box<dyn std::error::Error>> {
+        let token = AzureCliAuth::get_token()?;
+
+        let url = format!(
+            "https://management.azure.com/subscriptions/{}/resourceGroups/{}/providers/Microsoft.Compute/virtualMachines?api-version=2023-09-01",
+            self.subscription_id,
+            resource_group
+        );
+
+        let res = self.client.get(url).bearer_auth(token).send().await?;
+
+        let status = res.status();
+        let body_text = res.text().await?;
+
+        println!("-------------------------------");
+        println!("AZURE API DEBUG");
+        println!("Status  : {}", status);
+        println!("Response: {}", body_text);
+        println!("-------------------------------");
+
+        if !status.is_success() {
+            return Err(format!("Azure list VM instances failed: {}", body_text).into());
+        }
+
+        Ok(())
+    }
+
+    pub async fn start_vm(
+        &self,
+        resource_group: &str,
+        vm_name: &str,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let token = AzureCliAuth::get_token()?;
+
+        let url = format!(
+            "https://management.azure.com/subscriptions/{}/resourceGroups/{}/providers/Microsoft.Compute/virtualMachines/{}/start?api-version=2023-09-01",
+            self.subscription_id,
+            resource_group,
+            vm_name
+        );
+
+        let res = self
+            .client
+            .post(url)
+            .bearer_auth(token)
+            .header("Content-Length", "0")
+            .send()
+            .await?;
+
+        let status = res.status();
+        let body_text = res.text().await?;
+
+        println!("-------------------------------");
+        println!("AZURE API DEBUG");
+        println!("Status  : {}", status);
+        println!("Response: {}", body_text);
+        println!("-------------------------------");
+
+        if !status.is_success() {
+            return Err(format!("Azure start VM instance failed: {}", body_text).into());
+        }
+
+        Ok(())
+    }
+
+    pub async fn stop_vm(
+        &self,
+        resource_group: &str,
+        vm_name: &str,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let token = AzureCliAuth::get_token()?;
+
+        let url = format!(
+            "https://management.azure.com/subscriptions/{}/resourceGroups/{}/providers/Microsoft.Compute/virtualMachines/{}/powerOff?api-version=2023-09-01",
+            self.subscription_id,
+            resource_group,
+            vm_name
+        );
+
+        let res = self
+            .client
+            .post(url)
+            .bearer_auth(token)
+            .header("Content-Length", "0")
+            .send()
+            .await?;
+
+        let status = res.status();
+        let body_text = res.text().await?;
+
+        println!("-------------------------------");
+        println!("AZURE API DEBUG");
+        println!("Status  : {}", status);
+        println!("Response: {}", body_text);
+        println!("-------------------------------");
+
+        if !status.is_success() {
+            return Err(format!("Azure stop VM instance failed: {}", body_text).into());
+        }
+
+        Ok(())
+    }
+
+    pub async fn get_vm(
+        &self,
+        resource_group: &str,
+        vm_name: &str,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let token = AzureCliAuth::get_token()?;
+
+        let url = format!(
+        "https://management.azure.com/subscriptions/{}/resourceGroups/{}/providers/Microsoft.Compute/virtualMachines/{}?api-version=2023-09-01",
+        self.subscription_id,
+        resource_group,
+        vm_name
+    );
+
+        let res = self.client.get(url).bearer_auth(token).send().await?;
+
+        let status = res.status();
+        let body_text = res.text().await?;
+
+        println!("-------------------------------");
+        println!("AZURE API DEBUG");
+        println!("Status  : {}", status);
+        println!("Response: {}", body_text);
+        println!("-------------------------------");
+
+        if !status.is_success() {
+            return Err(format!("Azure get VM instance details failed: {}", body_text).into());
+        }
+
+        Ok(())
+    }
+
+    pub async fn restart_vm(
+        &self,
+        resource_group: &str,
+        vm_name: &str,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let token = AzureCliAuth::get_token()?;
+
+        let url = format!(
+        "https://management.azure.com/subscriptions/{}/resourceGroups/{}/providers/Microsoft.Compute/virtualMachines/{}/restart?api-version=2023-09-01",
+        self.subscription_id,
+        resource_group,
+        vm_name
+    );
+
+        let res = self
+            .client
+            .post(url)
+            .bearer_auth(token)
+            .header("Content-Length", "0")
+            .send()
+            .await?;
+
+        let status = res.status();
+        let body_text = res.text().await?;
+
+        println!("-------------------------------");
+        println!("AZURE API DEBUG");
+        println!("Status  : {}", status);
+        println!("Response: {}", body_text);
+        println!("-------------------------------");
+
+        if !status.is_success() {
+            return Err(format!("Azure VM instance restart failed: {}", body_text).into());
+        }
+
+        Ok(())
+    }
+
+    pub async fn delete_vm(
+        &self,
+        resource_group: &str,
+        vm_name: &str,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let token = AzureCliAuth::get_token()?;
+
+        let url = format!(
+        "https://management.azure.com/subscriptions/{}/resourceGroups/{}/providers/Microsoft.Compute/virtualMachines/{}?api-version=2023-09-01",
+        self.subscription_id,
+        resource_group,
+        vm_name
+    );
+
+        let res = self.client.delete(url).bearer_auth(token).send().await?;
+
+        let status = res.status();
+        let body_text = res.text().await?;
+
+        println!("-------------------------------");
+        println!("AZURE API DEBUG");
+        println!("Status  : {}", status);
+        println!("Response: {}", body_text);
+        println!("-------------------------------");
+
+        if !status.is_success() {
+            return Err(format!("Azure VM instance deletion failed: {}", body_text).into());
+        }
+
+        Ok(())
+    }
+
+    pub async fn vm_instance_view(
+        &self,
+        resource_group: &str,
+        vm_name: &str,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let token = AzureCliAuth::get_token()?;
+
+        let url = format!(
+        "https://management.azure.com/subscriptions/{}/resourceGroups/{}/providers/Microsoft.Compute/virtualMachines/{}/instanceView?api-version=2023-09-01",
+        self.subscription_id,
+        resource_group,
+        vm_name
+    );
+
+        let res = self.client.get(url).bearer_auth(token).send().await?;
+
+        let status = res.status();
+        let body_text = res.text().await?;
+
+        println!("-------------------------------");
+        println!("AZURE API DEBUG");
+        println!("Status  : {}", status);
+        println!("Response: {}", body_text);
+        println!("-------------------------------");
+
+        if !status.is_success() {
+            return Err(format!("Azure VM instance view failed: {}", body_text).into());
+        }
+
+        Ok(())
+    }
+}

--- a/rustcloud/src/azure/azure_apis/compute/mod.rs
+++ b/rustcloud/src/azure/azure_apis/compute/mod.rs
@@ -1,0 +1,1 @@
+pub mod azure_vm;

--- a/rustcloud/src/azure/azure_apis/management/azure_resource_group.rs
+++ b/rustcloud/src/azure/azure_apis/management/azure_resource_group.rs
@@ -1,0 +1,61 @@
+use crate::azure::azure_apis::auth::azure_cli_auth::AzureCliAuth;
+use reqwest::Client;
+use std::env;
+
+pub struct AzureResourceGroupClient {
+    client: Client,
+    subscription_id: String,
+}
+
+impl AzureResourceGroupClient {
+    pub fn new() -> Self {
+        let subscription_id =
+            env::var("AZURE_SUBSCRIPTION_ID").expect("AZURE_SUBSCRIPTION_ID not set");
+
+        Self {
+            client: Client::new(),
+            subscription_id,
+        }
+    }
+
+    pub async fn create_resource_group(
+        &self,
+        resource_group: &str,
+        location: &str,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let token = AzureCliAuth::get_token()?;
+
+        let url = format!(
+            "https://management.azure.com/subscriptions/{}/resourcegroups/{}?api-version=2023-07-01",
+            self.subscription_id,
+            resource_group
+        );
+
+        let body = serde_json::json!({
+            "location": location
+        });
+
+        let res = self
+            .client
+            .put(url)
+            .bearer_auth(token)
+            .json(&body)
+            .send()
+            .await?;
+
+        let status = res.status();
+        let body_text = res.text().await?;
+
+        println!("-------------------------------");
+        println!("AZURE API DEBUG");
+        println!("Status  : {}", status);
+        println!("Response: {}", body_text);
+        println!("-------------------------------");
+
+        if !status.is_success() {
+            return Err(format!("Azure Resource Group creation failed: {}", body_text).into());
+        }
+
+        Ok(())
+    }
+}

--- a/rustcloud/src/azure/azure_apis/management/mod.rs
+++ b/rustcloud/src/azure/azure_apis/management/mod.rs
@@ -1,0 +1,1 @@
+pub mod azure_resource_group;

--- a/rustcloud/src/azure/azure_apis/mod.rs
+++ b/rustcloud/src/azure/azure_apis/mod.rs
@@ -1,2 +1,5 @@
 pub mod auth;
 pub mod storage;
+pub mod compute;
+pub mod network;
+pub mod management;

--- a/rustcloud/src/azure/azure_apis/network/azure_nic.rs
+++ b/rustcloud/src/azure/azure_apis/network/azure_nic.rs
@@ -1,0 +1,76 @@
+use crate::azure::azure_apis::auth::azure_cli_auth::AzureCliAuth;
+use reqwest::Client;
+use std::env;
+
+pub struct AzureNICClient {
+    client: Client,
+    subscription_id: String,
+}
+
+impl AzureNICClient {
+    pub fn new() -> Self {
+        let subscription_id =
+            env::var("AZURE_SUBSCRIPTION_ID").expect("AZURE_SUBSCRIPTION_ID not set");
+
+        Self {
+            client: Client::new(),
+            subscription_id,
+        }
+    }
+
+    pub async fn create_nic(
+        &self,
+        resource_group: &str,
+        nic_name: &str,
+        location: &str,
+        subnet_id: &str,
+        public_ip_id: &str,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let token = AzureCliAuth::get_token()?;
+
+        let url = format!(
+            "https://management.azure.com/subscriptions/{}/resourceGroups/{}/providers/Microsoft.Network/networkInterfaces/{}?api-version=2023-09-01",
+            self.subscription_id,
+            resource_group,
+            nic_name
+        );
+
+        let body = serde_json::json!({
+            "location": location,
+            "properties": {
+                "ipConfigurations": [
+                    {
+                        "name": "ipconfig1",
+                        "properties": {
+                            "subnet": { "id": subnet_id },
+                            "publicIPAddress": { "id": public_ip_id }
+                        }
+                    }
+                ]
+            }
+        });
+
+        let res = self
+            .client
+            .put(url)
+            .bearer_auth(token)
+            .json(&body)
+            .send()
+            .await?;
+
+        let status = res.status();
+        let body_text = res.text().await?;
+
+        println!("-------------------------------");
+        println!("AZURE API DEBUG");
+        println!("Status  : {}", status);
+        println!("Response: {}", body_text);
+        println!("-------------------------------");
+
+        if !status.is_success() {
+            return Err(format!("Azure NIC creation failed: {}", body_text).into());
+        }
+
+        Ok(())
+    }
+}

--- a/rustcloud/src/azure/azure_apis/network/azure_public_ip.rs
+++ b/rustcloud/src/azure/azure_apis/network/azure_public_ip.rs
@@ -1,0 +1,66 @@
+use crate::azure::azure_apis::auth::azure_cli_auth::AzureCliAuth;
+use reqwest::Client;
+use std::env;
+
+pub struct AzurePublicIPClient {
+    client: Client,
+    subscription_id: String,
+}
+
+impl AzurePublicIPClient {
+    pub fn new() -> Self {
+        let subscription_id =
+            env::var("AZURE_SUBSCRIPTION_ID").expect("AZURE_SUBSCRIPTION_ID not set");
+
+        Self {
+            client: Client::new(),
+            subscription_id,
+        }
+    }
+
+    pub async fn create_public_ip(
+        &self,
+        resource_group: &str,
+        ip_name: &str,
+        location: &str,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let token = AzureCliAuth::get_token()?;
+
+        let url = format!(
+            "https://management.azure.com/subscriptions/{}/resourceGroups/{}/providers/Microsoft.Network/publicIPAddresses/{}?api-version=2023-09-01",
+            self.subscription_id,
+            resource_group,
+            ip_name
+        );
+
+        let body = serde_json::json!({
+            "location": location,
+            "properties": {
+                "publicIPAllocationMethod": "Dynamic"
+            }
+        });
+
+        let res = self
+            .client
+            .put(url)
+            .bearer_auth(token)
+            .json(&body)
+            .send()
+            .await?;
+
+        let status = res.status();
+        let body_text = res.text().await?;
+
+        println!("-------------------------------");
+        println!("AZURE API DEBUG");
+        println!("Status  : {}", status);
+        println!("Response: {}", body_text);
+        println!("-------------------------------");
+
+        if !status.is_success() {
+            return Err(format!("Azure Public IP creation failed: {}", body_text).into());
+        }
+
+        Ok(())
+    }
+}

--- a/rustcloud/src/azure/azure_apis/network/azure_subnet.rs
+++ b/rustcloud/src/azure/azure_apis/network/azure_subnet.rs
@@ -1,0 +1,66 @@
+use crate::azure::azure_apis::auth::azure_cli_auth::AzureCliAuth;
+use reqwest::Client;
+use std::env;
+
+pub struct AzureSubnetClient {
+    client: Client,
+    subscription_id: String,
+}
+
+impl AzureSubnetClient {
+    pub fn new() -> Self {
+        let subscription_id =
+            env::var("AZURE_SUBSCRIPTION_ID").expect("AZURE_SUBSCRIPTION_ID not set");
+
+        Self {
+            client: Client::new(),
+            subscription_id,
+        }
+    }
+
+    pub async fn create_subnet(
+        &self,
+        resource_group: &str,
+        vnet_name: &str,
+        subnet_name: &str,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let token = AzureCliAuth::get_token()?;
+
+        let url = format!(
+            "https://management.azure.com/subscriptions/{}/resourceGroups/{}/providers/Microsoft.Network/virtualNetworks/{}/subnets/{}?api-version=2023-09-01",
+            self.subscription_id,
+            resource_group,
+            vnet_name,
+            subnet_name
+        );
+
+        let body = serde_json::json!({
+            "properties": {
+                "addressPrefix": "10.0.1.0/24"
+            }
+        });
+
+        let res = self
+            .client
+            .put(url)
+            .bearer_auth(token)
+            .json(&body)
+            .send()
+            .await?;
+
+        let status = res.status();
+        let body_text = res.text().await?;
+
+        println!("-------------------------------");
+        println!("AZURE API DEBUG");
+        println!("Status  : {}", status);
+        println!("Response: {}", body_text);
+        println!("-------------------------------");
+
+        if !status.is_success() {
+            return Err(format!("Azure Subnet creation failed: {}", body_text).into());
+        }
+
+        Ok(())
+    }
+}

--- a/rustcloud/src/azure/azure_apis/network/azure_vnet.rs
+++ b/rustcloud/src/azure/azure_apis/network/azure_vnet.rs
@@ -1,0 +1,68 @@
+use crate::azure::azure_apis::auth::azure_cli_auth::AzureCliAuth;
+use reqwest::Client;
+use std::env;
+
+pub struct AzureVNetClient {
+    client: Client,
+    subscription_id: String,
+}
+
+impl AzureVNetClient {
+    pub fn new() -> Self {
+        let subscription_id =
+            env::var("AZURE_SUBSCRIPTION_ID").expect("AZURE_SUBSCRIPTION_ID not set");
+
+        Self {
+            client: Client::new(),
+            subscription_id,
+        }
+    }
+
+    pub async fn create_vnet(
+        &self,
+        resource_group: &str,
+        vnet_name: &str,
+        location: &str,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let token = AzureCliAuth::get_token()?;
+
+        let url = format!(
+            "https://management.azure.com/subscriptions/{}/resourceGroups/{}/providers/Microsoft.Network/virtualNetworks/{}?api-version=2023-09-01",
+            self.subscription_id,
+            resource_group,
+            vnet_name
+        );
+
+        let body = serde_json::json!({
+            "location": location,
+            "properties": {
+                "addressSpace": {
+                    "addressPrefixes": ["10.0.0.0/16"]
+                }
+            }
+        });
+
+        let res = self
+            .client
+            .put(url)
+            .bearer_auth(token)
+            .json(&body)
+            .send()
+            .await?;
+
+        let status = res.status();
+        let body_text = res.text().await?;
+
+        println!("-------------------------------");
+        println!("AZURE API DEBUG");
+        println!("Status  : {}", status);
+        println!("Response: {}", body_text);
+        println!("-------------------------------");
+
+        if !status.is_success() {
+            return Err(format!("Azure VNet creation failed: {}", body_text).into());
+        }
+
+        Ok(())
+    }
+}

--- a/rustcloud/src/azure/azure_apis/network/mod.rs
+++ b/rustcloud/src/azure/azure_apis/network/mod.rs
@@ -1,0 +1,4 @@
+pub mod azure_nic;
+pub mod azure_public_ip;
+pub mod azure_subnet;
+pub mod azure_vnet;

--- a/rustcloud/src/main.rs
+++ b/rustcloud/src/main.rs
@@ -11,9 +11,23 @@ pub mod azure{
     pub mod azure_apis{
         pub mod auth{
             pub mod azure_auth;
+            pub mod azure_cli_auth;
+
+        }
+        pub mod management{
+            pub mod azure_resource_group;
+        }
+        pub mod network{
+            pub mod azure_nic;
+            pub mod azure_public_ip;
+            pub mod azure_subnet;
+            pub mod azure_vnet;
         }
         pub mod storage{
             pub mod azure_blob;
+        }
+        pub mod compute{
+            pub mod azure_vm;
         }
     }
 }

--- a/rustcloud/src/tests/azure_nic_operations.rs
+++ b/rustcloud/src/tests/azure_nic_operations.rs
@@ -1,0 +1,20 @@
+use crate::azure::azure_apis::network::azure_nic::AzureNICClient;
+
+#[tokio::test]
+async fn test_create_nic() {
+    let client = AzureNICClient::new();
+
+    let subnet_id = "/subscriptions/<SUBSCRIPTION_ID>/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-subnet";
+    let public_ip_id = "/subscriptions/<SUBSCRIPTION_ID>/resourceGroups/test-rg/providers/Microsoft.Network/publicIPAddresses/test-ip";
+
+    let result = client
+        .create_nic("test-rg", "test-nic", "eastasia", subnet_id, public_ip_id)
+        .await;
+
+    match &result {
+        Ok(_) => println!("NIC created successfully"),
+        Err(e) => println!("Azure NIC creation failed with error: {:?}", e),
+    }
+
+    assert!(result.is_ok(), "Detailed error: {:?}", result);
+}

--- a/rustcloud/src/tests/azure_public_ip_operations.rs
+++ b/rustcloud/src/tests/azure_public_ip_operations.rs
@@ -1,0 +1,17 @@
+use crate::azure::azure_apis::network::azure_public_ip::AzurePublicIPClient;
+
+#[tokio::test]
+async fn test_create_public_ip() {
+    let client = AzurePublicIPClient::new();
+
+    let result = client
+        .create_public_ip("test-rg", "test-ip", "eastasia")
+        .await;
+
+    match &result {
+        Ok(_) => println!("Public IP created successfully"),
+        Err(e) => println!("Azure Public IP creation failed with error: {:?}", e),
+    }
+
+    assert!(result.is_ok(), "Detailed error: {:?}", result);
+}

--- a/rustcloud/src/tests/azure_resource_group_operations.rs
+++ b/rustcloud/src/tests/azure_resource_group_operations.rs
@@ -1,0 +1,17 @@
+use crate::azure::azure_apis::management::azure_resource_group::AzureResourceGroupClient;
+
+#[tokio::test]
+async fn test_create_resource_group() {
+    let client = AzureResourceGroupClient::new();
+
+    let result = client
+        .create_resource_group("rustcloud-rg", "eastasia")
+        .await;
+
+    match &result {
+        Ok(_) => println!("Resource Group created successfully"),
+        Err(e) => println!("Azure Resource Group creation failed with error: {:?}", e),
+    }
+
+    assert!(result.is_ok(), "Detailed error: {:?}", result);
+}

--- a/rustcloud/src/tests/azure_subnet_operations.rs
+++ b/rustcloud/src/tests/azure_subnet_operations.rs
@@ -1,0 +1,17 @@
+use crate::azure::azure_apis::network::azure_subnet::AzureSubnetClient;
+
+#[tokio::test]
+async fn test_create_subnet() {
+    let client = AzureSubnetClient::new();
+
+    let result = client
+        .create_subnet("test-rg", "test-vnet", "test-subnet")
+        .await;
+
+    match &result {
+        Ok(_) => println!("Subnet created successfully"),
+        Err(e) => println!("Azure Subnet creation failed with error: {:?}", e),
+    }
+
+    assert!(result.is_ok(), "Detailed error: {:?}", result);
+}

--- a/rustcloud/src/tests/azure_vm_operations.rs
+++ b/rustcloud/src/tests/azure_vm_operations.rs
@@ -1,0 +1,119 @@
+use crate::azure::azure_apis::compute::azure_vm::AzureVMClient;
+
+#[tokio::test]
+async fn test_create_vm() {
+    let client = AzureVMClient::new();
+
+    let nic_id =
+        "/subscriptions/<SUBSCRIPTION_ID>/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/test-nic";
+
+    let result = client
+        .create_vm("test-rg", "test-vm", "eastasia", nic_id)
+        .await;
+
+    match &result {
+        Ok(_) => println!("VM created successfully"),
+        Err(e) => println!("Azure VM creation failed with error: {:?}", e),
+    }
+
+    assert!(result.is_ok(), "Detailed error: {:?}", result);
+}
+
+#[tokio::test]
+async fn test_list_vms() {
+    let client = AzureVMClient::new();
+    let resource_group = "test-rg";
+
+    let result = client.list_vms(resource_group).await;
+
+    match &result {
+        Ok(vms) => println!("List VMs result: {:?}", vms),
+        Err(e) => println!("Azure list VMs failed with error: {:?}", e),
+    }
+
+    assert!(result.is_ok(), "Azure error: {:?}", result);
+}
+
+#[tokio::test]
+async fn test_start_vm() {
+    let client = AzureVMClient::new();
+
+    let result = client.start_vm("test-rg", "test-vm").await;
+
+    match &result {
+        Ok(_) => println!("VM started successfully"),
+        Err(e) => println!("Azure VM start failed with error: {:?}", e),
+    }
+
+    assert!(result.is_ok(), "Azure error: {:?}", result);
+}
+
+#[tokio::test]
+async fn test_stop_vm() {
+    let client = AzureVMClient::new();
+
+    let result = client.stop_vm("test-rg", "test-vm").await;
+
+    match &result {
+        Ok(_) => println!("VM stopped successfully"),
+        Err(e) => println!("Azure VM stop failed with error: {:?}", e),
+    }
+
+    assert!(result.is_ok(), "Azure error: {:?}", result);
+}
+
+#[tokio::test]
+async fn test_get_vm() {
+    let client = AzureVMClient::new();
+
+    let result = client.get_vm("test-rg", "test-vm").await;
+
+    match &result {
+        Ok(vm) => println!("Get VM result: {:?}", vm),
+        Err(e) => println!("Azure get VM failed with error: {:?}", e),
+    }
+
+    assert!(result.is_ok(), "Azure error: {:?}", result);
+}
+
+#[tokio::test]
+async fn test_restart_vm() {
+    let client = AzureVMClient::new();
+
+    let result = client.restart_vm("test-rg", "test-vm").await;
+
+    match &result {
+        Ok(_) => println!("VM restarted successfully"),
+        Err(e) => println!("Azure VM restart failed with error: {:?}", e),
+    }
+
+    assert!(result.is_ok(), "Azure error: {:?}", result);
+}
+
+#[tokio::test]
+async fn test_delete_vm() {
+    let client = AzureVMClient::new();
+
+    let result = client.delete_vm("test-rg", "test-vm").await;
+
+    match &result {
+        Ok(_) => println!("VM deleted successfully"),
+        Err(e) => println!("Azure VM deletion failed with error: {:?}", e),
+    }
+
+    assert!(result.is_ok(), "Detailed error: {:?}", result);
+}
+
+#[tokio::test]
+async fn test_vm_instance_view() {
+    let client = AzureVMClient::new();
+
+    let result = client.vm_instance_view("test-rg", "test-vm").await;
+
+    match &result {
+        Ok(view) => println!("VM Instance view result: {:?}", view),
+        Err(e) => println!("Azure VM Instance view failed with error: {:?}", e),
+    }
+
+    assert!(result.is_ok(), "Detailed error: {:?}", result);
+}

--- a/rustcloud/src/tests/azure_vnet_operations.rs
+++ b/rustcloud/src/tests/azure_vnet_operations.rs
@@ -1,0 +1,15 @@
+use crate::azure::azure_apis::network::azure_vnet::AzureVNetClient;
+
+#[tokio::test]
+async fn test_create_vnet() {
+    let client = AzureVNetClient::new();
+
+    let result = client.create_vnet("test-rg", "test-vnet", "eastasia").await;
+
+    match &result {
+        Ok(_) => println!("VNet created successfully"),
+        Err(e) => println!("Azure VNet creation failed with error: {:?}", e),
+    }
+
+    assert!(result.is_ok(), "Detailed error: {:?}", result);
+}

--- a/rustcloud/src/tests/mod.rs
+++ b/rustcloud/src/tests/mod.rs
@@ -1,4 +1,10 @@
 mod azure_blob_operations;
+mod azure_vm_operations;
+mod azure_nic_operations;
+mod azure_public_ip_operations;
+mod azure_resource_group_operations;
+mod azure_subnet_operations;
+mod azure_vnet_operations;
 mod aws_archival_operations;
 mod aws_block_operations;
 mod aws_bucket_operations;


### PR DESCRIPTION
Closes #47 

## Summary
This PR adds support for Azure networking, VM, and resource group operations in RustCloud.

## Implemented Services
- Azure Resource Group
- Azure Virtual Network (VNet)
- Azure Subnet
- Azure Public IP
- Azure Network Interface (NIC)
- Azure Virtual Machine

## Methodology
Azure resources are managed using the Azure REST API.  
Authentication is handled using **Azure CLI**, where **access tokens are retrieved from the Azure CLI session** and used to authorize requests to Azure resource management APIs.

Before running tests, login using Azure CLI:

```bash
az login
```

Set the subscription ID as an environment variable.

Linux/macOS:

```bash
export AZURE_SUBSCRIPTION_ID=<subscription-id>
```

Windows PowerShell:

```powershell
$env:AZURE_SUBSCRIPTION_ID="<subscription-id>"
```

## Running Tests

Resource Group:

```bash
cargo test test_create_resource_group -- --nocapture
```

Networking:

```bash
cargo test test_create_vnet -- --nocapture
cargo test test_create_subnet -- --nocapture
cargo test test_create_public_ip -- --nocapture
cargo test test_create_nic -- --nocapture
```

Virtual Machine:

```bash
cargo test test_create_vm -- --nocapture
cargo test test_list_vms -- --nocapture
cargo test test_get_vm -- --nocapture
cargo test test_start_vm -- --nocapture
cargo test test_stop_vm -- --nocapture
cargo test test_restart_vm -- --nocapture
cargo test test_vm_instance_view -- --nocapture
cargo test test_delete_vm -- --nocapture
```

## Notes
Tests assume the Azure account has sufficient permissions to create resources.