### PR TITLE
feat(gcp): migrate AutoML to Vertex AI + implement LlmProvider

### DIFF
--- a/rustcloud/Cargo.toml
+++ b/rustcloud/Cargo.toml
@@ -30,9 +30,9 @@ gcloud-sdk = "0.24.7"
 gcp_auth = "0.12.2"
 hmac = "0.12.1"
 mockall = "=0.9.1"
-reqwest = "0.12.5"
+reqwest = { version = "0.12.5", features = ["json", "stream"] }
 rustls = { version = "0.23", features = ["ring"] }
-serde = "1.0.203"
+serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.118"
 sha2 = "0.10.9"
 

--- a/rustcloud/src/aws/aws_apis/compute/aws_ec2.rs
+++ b/rustcloud/src/aws/aws_apis/compute/aws_ec2.rs
@@ -24,8 +24,10 @@ pub async fn create_instance(
                     "No instances were created",
                 )));
             }
-            let instance_id =
-                run_instances.instances()[0].instance_id().unwrap().to_string();
+            let instance_id = run_instances.instances()[0]
+                .instance_id()
+                .unwrap()
+                .to_string();
             if let Err(e) = client
                 .create_tags()
                 .resources(&instance_id)

--- a/rustcloud/src/azure/azure_apis/auth/azure_auth.rs
+++ b/rustcloud/src/azure/azure_apis/auth/azure_auth.rs
@@ -6,25 +6,21 @@ use std::env;
 type HmacSha256 = Hmac<Sha256>;
 pub struct AzureAuth;
 
-
 impl AzureAuth {
     pub fn generate_headers(method: &str, account: &str, resource: &str) -> (String, String) {
-
         let key = env::var("AZURE_STORAGE_KEY").expect("AZURE_STORAGE_KEY not set");
-        
+
         let date = Utc::now().format("%a, %d %b %Y %H:%M:%S GMT").to_string();
-        
+
         let mut path = resource.to_string();
-        
+
         let mut query = String::new();
 
         if let Some(pos) = resource.find('?') {
             path = resource[..pos].to_string();
-        
+
             query = resource[pos + 1..].to_string();
         }
-
-
 
         let canonicalized_resource = if query.is_empty() {
             format!("/{}{}", account, path)
@@ -42,22 +38,18 @@ impl AzureAuth {
         let string_to_sign = format!(
             "{}\n\n\n\n\n\n\n\n\n\n\n\nx-ms-date:{}\nx-ms-version:2020-10-02\n{}",
             method, date, canonicalized_resource
-      
         );
 
         let decoded_key = general_purpose::STANDARD.decode(key).unwrap();
-        
 
         let mut mac = HmacSha256::new_from_slice(&decoded_key).unwrap();
-        
+
         mac.update(string_to_sign.as_bytes());
-        
+
         let signature = general_purpose::STANDARD.encode(mac.finalize().into_bytes());
 
-        
         let auth_header = format!("SharedKey {}:{}", account, signature);
 
         (auth_header, date)
-
     }
 }

--- a/rustcloud/src/azure/azure_apis/storage/azure_blob.rs
+++ b/rustcloud/src/azure/azure_apis/storage/azure_blob.rs
@@ -3,7 +3,6 @@ use std::error::Error;
 
 use crate::azure::azure_apis::auth::azure_auth::AzureAuth;
 
-
 pub struct AzureBlobClient {
     client: Client,
     account: String,
@@ -12,9 +11,7 @@ pub struct AzureBlobClient {
 
 impl AzureBlobClient {
     pub fn new(account: String) -> Self {
-
         let base_url = format!("https://{}.blob.core.windows.net", account);
-
 
         AzureBlobClient {
             client: Client::new(),
@@ -24,14 +21,12 @@ impl AzureBlobClient {
     }
 
     pub async fn list_containers(&self) -> Result<String, Box<dyn Error>> {
-        
         let resource = "/?comp=list";
-        
+
         let (auth, date) = AzureAuth::generate_headers("GET", &self.account, resource);
-        
 
         let url = format!("{}?comp=list", self.base_url);
-        
+
         let response = self
             .client
             .get(&url)
@@ -40,26 +35,23 @@ impl AzureBlobClient {
             .header("Authorization", auth)
             .send()
             .await?;
-        
+
         let status = response.status();
         let body = response.text().await?;
-        
+
         if !status.is_success() {
             return Err(format!("Azure error: {}", body).into());
         }
-        
-        Ok(body)
 
+        Ok(body)
     }
 
-    
     pub async fn create_container(&self, container: &str) -> Result<String, Box<dyn Error>> {
-        
         let resource = format!("/{}?restype=container", container);
-        
+
         let (auth, date) = AzureAuth::generate_headers("PUT", &self.account, &resource);
         let url = format!("{}/{}?restype=container", self.base_url, container);
-        
+
         let response = self
             .client
             .put(&url)
@@ -69,27 +61,25 @@ impl AzureBlobClient {
             .header("Authorization", auth)
             .send()
             .await?;
-        
+
         let status = response.status();
-        
+
         let body = response.text().await?;
-        
+
         if !status.is_success() {
             return Err(format!("Azure error: {}", body).into());
         }
-        
+
         Ok(body)
     }
-    
-    
+
     pub async fn delete_container(&self, container: &str) -> Result<String, Box<dyn Error>> {
-        
         let resource = format!("/{}?restype=container", container);
-        
+
         let (auth, date) = AzureAuth::generate_headers("DELETE", &self.account, &resource);
-        
+
         let url = format!("{}/{}?restype=container", self.base_url, container);
-        
+
         let response = self
             .client
             .delete(&url)
@@ -98,15 +88,15 @@ impl AzureBlobClient {
             .header("Authorization", auth)
             .send()
             .await?;
-        
+
         let status = response.status();
-        
+
         let body = response.text().await?;
-        
+
         if !status.is_success() {
             return Err(format!("Azure error: {}", body).into());
         }
-        
+
         Ok(body)
     }
 }

--- a/rustcloud/src/gcp/gcp_apis/artificial_intelligence/gcp_automl.rs
+++ b/rustcloud/src/gcp/gcp_apis/artificial_intelligence/gcp_automl.rs
@@ -4,6 +4,10 @@ use reqwest::{header::AUTHORIZATION, Client, Response};
 use serde_json::to_string;
 use std::collections::HashMap;
 
+#[deprecated(
+    since = "0.2.0",
+    note = "Use VertexAI instead. Google AutoML API is deprecated in favor of Vertex AI."
+)]
 pub struct AutoML {
     client: Client,
     base_url: String,

--- a/rustcloud/src/gcp/gcp_apis/artificial_intelligence/gcp_vertex_ai.rs
+++ b/rustcloud/src/gcp/gcp_apis/artificial_intelligence/gcp_vertex_ai.rs
@@ -1,0 +1,706 @@
+use async_trait::async_trait;
+use futures::stream::{self, StreamExt};
+use reqwest::{header::AUTHORIZATION, Client, Response};
+use std::pin::Pin;
+
+use crate::errors::CloudError;
+use crate::gcp::gcp_apis::auth::gcp_auth::retrieve_token;
+use crate::gcp::types::artificial_intelligence::gcp_vertex_ai_types::*;
+use crate::traits::llm_provider::{LlmProvider, LlmStream};
+use crate::types::llm::{
+    EmbedResponse, FinishReason, LlmRequest, LlmResponse, LlmStreamEvent, ModelRef,
+    ToolCallResponse, ToolDefinition, UsageStats,
+};
+
+/// Vertex AI client for GCP's modern AI platform.
+///
+/// This replaces the deprecated AutoML API and implements the `LlmProvider` trait
+/// for Gemini model access.
+pub struct VertexAI {
+    client: Client,
+    project_id: String,
+    location: String,
+}
+
+impl VertexAI {
+    /// Create a new VertexAI client.
+    ///
+    /// # Arguments
+    /// * `project_id` - Your GCP project ID
+    /// * `location` - The GCP region (e.g., "us-central1")
+    pub fn new(project_id: &str, location: &str) -> Self {
+        Self {
+            client: Client::new(),
+            project_id: project_id.to_string(),
+            location: location.to_string(),
+        }
+    }
+
+    /// Construct the regional base URL for Vertex AI.
+    fn base_url(&self) -> String {
+        format!(
+            "https://{}-aiplatform.googleapis.com/v1/projects/{}/locations/{}",
+            self.location, self.project_id, self.location
+        )
+    }
+
+    /// Retrieve a bearer token, mapping errors to CloudError::Auth.
+    async fn get_auth_token(&self) -> Result<String, CloudError> {
+        retrieve_token().await.map_err(|e| CloudError::Auth {
+            message: e.to_string(),
+        })
+    }
+
+    /// Resolve a ModelRef to a concrete Vertex AI model ID string.
+    fn resolve_model(model: &ModelRef) -> Result<String, CloudError> {
+        match model {
+            ModelRef::Provider(id) => Ok(id.clone()),
+            ModelRef::Deployment(id) => Ok(id.clone()),
+            ModelRef::Logical { family, tier } => {
+                let model_id = match (family.as_str(), tier.as_deref()) {
+                    ("gemini", Some("pro")) | ("gemini", None) => "gemini-1.5-pro",
+                    ("gemini", Some("flash")) => "gemini-1.5-flash",
+                    ("gemini", Some("ultra")) => "gemini-ultra",
+                    _ => {
+                        return Err(CloudError::Unsupported {
+                            feature: "unknown model family/tier combination",
+                        })
+                    }
+                };
+                Ok(model_id.to_string())
+            }
+        }
+    }
+
+    // ─── Dataset Management ───
+
+    /// Create a new dataset in Vertex AI.
+    pub async fn create_dataset(
+        &self,
+        display_name: &str,
+        metadata_schema_uri: &str,
+    ) -> Result<Response, Box<dyn std::error::Error>> {
+        let url = format!("{}/datasets", self.base_url());
+        let dataset = VertexDataset {
+            name: None,
+            display_name: display_name.to_string(),
+            metadata_schema_uri: metadata_schema_uri.to_string(),
+            metadata: None,
+        };
+        let token = self
+            .get_auth_token()
+            .await
+            .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
+        self.client
+            .post(&url)
+            .header(AUTHORIZATION, format!("Bearer {}", token))
+            .json(&dataset)
+            .send()
+            .await
+            .map_err(|e| e.into())
+    }
+
+    /// Get a dataset by ID.
+    pub async fn get_dataset(
+        &self,
+        dataset_id: &str,
+    ) -> Result<Response, Box<dyn std::error::Error>> {
+        let url = format!("{}/datasets/{}", self.base_url(), dataset_id);
+        let token = self
+            .get_auth_token()
+            .await
+            .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
+        self.client
+            .get(&url)
+            .header(AUTHORIZATION, format!("Bearer {}", token))
+            .send()
+            .await
+            .map_err(|e| e.into())
+    }
+
+    /// Import data into a dataset from GCS.
+    pub async fn import_data(
+        &self,
+        dataset_id: &str,
+        gcs_uris: Vec<String>,
+        import_schema_uri: &str,
+    ) -> Result<Response, Box<dyn std::error::Error>> {
+        let url = format!("{}/datasets/{}:import", self.base_url(), dataset_id);
+        let config = ImportDataConfig {
+            gcs_source: GcsSource { uris: gcs_uris },
+            import_schema_uri: import_schema_uri.to_string(),
+        };
+        let body = serde_json::json!({ "importConfigs": [config] });
+        let token = self
+            .get_auth_token()
+            .await
+            .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
+        self.client
+            .post(&url)
+            .header(AUTHORIZATION, format!("Bearer {}", token))
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| e.into())
+    }
+
+    /// Export a dataset to GCS.
+    pub async fn export_dataset(
+        &self,
+        dataset_id: &str,
+        gcs_output_uri: &str,
+    ) -> Result<Response, Box<dyn std::error::Error>> {
+        let url = format!("{}/datasets/{}:export", self.base_url(), dataset_id);
+        let body = serde_json::json!({
+            "exportConfig": {
+                "gcsDestination": { "outputUriPrefix": gcs_output_uri }
+            }
+        });
+        let token = self
+            .get_auth_token()
+            .await
+            .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
+        self.client
+            .post(&url)
+            .header(AUTHORIZATION, format!("Bearer {}", token))
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| e.into())
+    }
+
+    /// Delete a dataset.
+    pub async fn delete_dataset(
+        &self,
+        dataset_id: &str,
+    ) -> Result<Response, Box<dyn std::error::Error>> {
+        let url = format!("{}/datasets/{}", self.base_url(), dataset_id);
+        let token = self
+            .get_auth_token()
+            .await
+            .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
+        self.client
+            .delete(&url)
+            .header(AUTHORIZATION, format!("Bearer {}", token))
+            .send()
+            .await
+            .map_err(|e| e.into())
+    }
+
+    // ─── Model Management ───
+
+    /// List all models in the project/location.
+    pub async fn list_models(&self) -> Result<Response, Box<dyn std::error::Error>> {
+        let url = format!("{}/models", self.base_url());
+        let token = self
+            .get_auth_token()
+            .await
+            .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
+        self.client
+            .get(&url)
+            .header(AUTHORIZATION, format!("Bearer {}", token))
+            .send()
+            .await
+            .map_err(|e| e.into())
+    }
+
+    /// Get a model by ID.
+    pub async fn get_model(
+        &self,
+        model_id: &str,
+    ) -> Result<Response, Box<dyn std::error::Error>> {
+        let url = format!("{}/models/{}", self.base_url(), model_id);
+        let token = self
+            .get_auth_token()
+            .await
+            .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
+        self.client
+            .get(&url)
+            .header(AUTHORIZATION, format!("Bearer {}", token))
+            .send()
+            .await
+            .map_err(|e| e.into())
+    }
+
+    /// Delete a model.
+    pub async fn delete_model(
+        &self,
+        model_id: &str,
+    ) -> Result<Response, Box<dyn std::error::Error>> {
+        let url = format!("{}/models/{}", self.base_url(), model_id);
+        let token = self
+            .get_auth_token()
+            .await
+            .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
+        self.client
+            .delete(&url)
+            .header(AUTHORIZATION, format!("Bearer {}", token))
+            .send()
+            .await
+            .map_err(|e| e.into())
+    }
+
+    // ─── Endpoint Management ───
+
+    /// Create a new endpoint for model deployment.
+    pub async fn create_endpoint(
+        &self,
+        display_name: &str,
+    ) -> Result<Response, Box<dyn std::error::Error>> {
+        let url = format!("{}/endpoints", self.base_url());
+        let body = CreateEndpointRequest {
+            display_name: display_name.to_string(),
+        };
+        let token = self
+            .get_auth_token()
+            .await
+            .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
+        self.client
+            .post(&url)
+            .header(AUTHORIZATION, format!("Bearer {}", token))
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| e.into())
+    }
+
+    /// Deploy a model to an endpoint.
+    pub async fn deploy_model(
+        &self,
+        endpoint_id: &str,
+        model_resource_name: &str,
+        display_name: &str,
+    ) -> Result<Response, Box<dyn std::error::Error>> {
+        let url = format!("{}/endpoints/{}:deployModel", self.base_url(), endpoint_id);
+        let body = DeployModelRequest {
+            deployed_model: DeployedModel {
+                model: model_resource_name.to_string(),
+                display_name: display_name.to_string(),
+                dedicated_resources: None,
+                automatic_resources: Some(AutomaticResources {
+                    min_replica_count: 1,
+                    max_replica_count: 1,
+                }),
+            },
+        };
+        let token = self
+            .get_auth_token()
+            .await
+            .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
+        self.client
+            .post(&url)
+            .header(AUTHORIZATION, format!("Bearer {}", token))
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| e.into())
+    }
+
+    /// Undeploy a model from an endpoint.
+    pub async fn undeploy_model(
+        &self,
+        endpoint_id: &str,
+        deployed_model_id: &str,
+    ) -> Result<Response, Box<dyn std::error::Error>> {
+        let url = format!(
+            "{}/endpoints/{}:undeployModel",
+            self.base_url(),
+            endpoint_id
+        );
+        let body = UndeployModelRequest {
+            deployed_model_id: deployed_model_id.to_string(),
+        };
+        let token = self
+            .get_auth_token()
+            .await
+            .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
+        self.client
+            .post(&url)
+            .header(AUTHORIZATION, format!("Bearer {}", token))
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| e.into())
+    }
+}
+
+// ─── LlmProvider Trait Implementation ───
+
+#[async_trait]
+impl LlmProvider for VertexAI {
+    async fn generate(&self, req: LlmRequest) -> Result<LlmResponse, CloudError> {
+        let model_id = Self::resolve_model(&req.model)?;
+        let url = format!(
+            "{}/publishers/google/models/{}:generateContent",
+            self.base_url(),
+            model_id
+        );
+
+        let gemini_req = build_gemini_request(&req, None);
+        let token = self.get_auth_token().await?;
+
+        let response = self
+            .client
+            .post(&url)
+            .header(AUTHORIZATION, format!("Bearer {}", token))
+            .json(&gemini_req)
+            .send()
+            .await
+            .map_err(|e| CloudError::Network { source: e })?;
+
+        let status = response.status().as_u16();
+        if status == 429 {
+            let retry_after = response
+                .headers()
+                .get("retry-after")
+                .and_then(|v| v.to_str().ok())
+                .and_then(|v| v.parse::<u64>().ok());
+            return Err(CloudError::RateLimit { retry_after });
+        }
+        if !response.status().is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(CloudError::Provider {
+                http_status: status,
+                message: body,
+                retryable: status >= 500,
+            });
+        }
+
+        let gemini_resp: GeminiResponse = response
+            .json()
+            .await
+            .map_err(|e| CloudError::Network { source: e })?;
+
+        parse_gemini_response(gemini_resp)
+    }
+
+    async fn stream(&self, req: LlmRequest) -> Result<LlmStream, CloudError> {
+        let model_id = Self::resolve_model(&req.model)?;
+        let url = format!(
+            "{}/publishers/google/models/{}:streamGenerateContent?alt=sse",
+            self.base_url(),
+            model_id
+        );
+
+        let gemini_req = build_gemini_request(&req, None);
+        let token = self.get_auth_token().await?;
+
+        let response = self
+            .client
+            .post(&url)
+            .header(AUTHORIZATION, format!("Bearer {}", token))
+            .json(&gemini_req)
+            .send()
+            .await
+            .map_err(|e| CloudError::Network { source: e })?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(CloudError::Provider {
+                http_status: status,
+                message: body,
+                retryable: status >= 500,
+            });
+        }
+
+        let byte_stream = response.bytes_stream();
+        let event_stream = byte_stream
+            .map(|chunk_result| match chunk_result {
+                Ok(bytes) => {
+                    let text = String::from_utf8_lossy(&bytes);
+                    parse_sse_chunk(&text)
+                }
+                Err(e) => vec![LlmStreamEvent::Error(CloudError::Network { source: e })],
+            })
+            .flat_map(stream::iter);
+
+        Ok(Box::pin(event_stream))
+    }
+
+    async fn embed(&self, texts: Vec<String>) -> Result<EmbedResponse, CloudError> {
+        let model_id = "text-embedding-004";
+        let url = format!(
+            "{}/publishers/google/models/{}:predict",
+            self.base_url(),
+            model_id
+        );
+
+        let embed_req = EmbedRequest {
+            instances: texts
+                .into_iter()
+                .map(|t| EmbedInstance { content: t })
+                .collect(),
+        };
+
+        let token = self.get_auth_token().await?;
+        let response = self
+            .client
+            .post(&url)
+            .header(AUTHORIZATION, format!("Bearer {}", token))
+            .json(&embed_req)
+            .send()
+            .await
+            .map_err(|e| CloudError::Network { source: e })?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(CloudError::Provider {
+                http_status: status,
+                message: body,
+                retryable: status >= 500,
+            });
+        }
+
+        let pred_resp: EmbedPredictResponse = response
+            .json()
+            .await
+            .map_err(|e| CloudError::Network { source: e })?;
+
+        Ok(EmbedResponse {
+            embeddings: pred_resp
+                .predictions
+                .into_iter()
+                .map(|p| p.embeddings.values)
+                .collect(),
+        })
+    }
+
+    async fn generate_with_tools(
+        &self,
+        req: LlmRequest,
+        tools: Vec<ToolDefinition>,
+    ) -> Result<ToolCallResponse, CloudError> {
+        let model_id = Self::resolve_model(&req.model)?;
+        let url = format!(
+            "{}/publishers/google/models/{}:generateContent",
+            self.base_url(),
+            model_id
+        );
+
+        let gemini_req = build_gemini_request(&req, Some(&tools));
+        let token = self.get_auth_token().await?;
+
+        let response = self
+            .client
+            .post(&url)
+            .header(AUTHORIZATION, format!("Bearer {}", token))
+            .json(&gemini_req)
+            .send()
+            .await
+            .map_err(|e| CloudError::Network { source: e })?;
+
+        let status = response.status().as_u16();
+        if status == 429 {
+            let retry_after = response
+                .headers()
+                .get("retry-after")
+                .and_then(|v| v.to_str().ok())
+                .and_then(|v| v.parse::<u64>().ok());
+            return Err(CloudError::RateLimit { retry_after });
+        }
+        if !response.status().is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(CloudError::Provider {
+                http_status: status,
+                message: body,
+                retryable: status >= 500,
+            });
+        }
+
+        let gemini_resp: GeminiResponse = response
+            .json()
+            .await
+            .map_err(|e| CloudError::Network { source: e })?;
+
+        parse_tool_call_response(gemini_resp)
+    }
+}
+
+// ─── Helper Functions ───
+
+/// Build a GeminiRequest from an LlmRequest and optional tool definitions.
+fn build_gemini_request(req: &LlmRequest, tools: Option<&Vec<ToolDefinition>>) -> GeminiRequest {
+    let contents: Vec<Content> = req
+        .messages
+        .iter()
+        .map(|msg| Content {
+            role: Some(map_role(&msg.role)),
+            parts: vec![Part {
+                text: Some(msg.content.clone()),
+                function_call: None,
+                function_response: None,
+            }],
+        })
+        .collect();
+
+    let system_instruction = req.system_prompt.as_ref().map(|prompt| Content {
+        role: None,
+        parts: vec![Part {
+            text: Some(prompt.clone()),
+            function_call: None,
+            function_response: None,
+        }],
+    });
+
+    let generation_config = if req.max_tokens.is_some() || req.temperature.is_some() {
+        Some(GenerationConfig {
+            max_output_tokens: req.max_tokens,
+            temperature: req.temperature,
+        })
+    } else {
+        None
+    };
+
+    let gemini_tools = tools.map(|t| {
+        vec![GeminiTool {
+            function_declarations: t
+                .iter()
+                .map(|td| FunctionDeclaration {
+                    name: td.name.clone(),
+                    description: td.description.clone(),
+                    parameters: td.parameters.clone(),
+                })
+                .collect(),
+        }]
+    });
+
+    GeminiRequest {
+        contents,
+        system_instruction,
+        generation_config,
+        tools: gemini_tools,
+    }
+}
+
+/// Map standard role names to Gemini role names.
+fn map_role(role: &str) -> String {
+    match role {
+        "assistant" => "model".to_string(),
+        other => other.to_string(),
+    }
+}
+
+/// Parse a GeminiResponse into an LlmResponse.
+fn parse_gemini_response(resp: GeminiResponse) -> Result<LlmResponse, CloudError> {
+    let candidate = resp
+        .candidates
+        .and_then(|c| c.into_iter().next())
+        .ok_or_else(|| CloudError::Provider {
+            http_status: 200,
+            message: "no candidates in response".to_string(),
+            retryable: false,
+        })?;
+
+    let text = candidate
+        .content
+        .and_then(|c| c.parts.into_iter().next())
+        .and_then(|p| p.text)
+        .unwrap_or_default();
+
+    let finish_reason = match candidate.finish_reason.as_deref() {
+        Some("STOP") => FinishReason::Stop,
+        Some("MAX_TOKENS") => FinishReason::Length,
+        Some("TOOL_CALL") | Some("FUNCTION_CALL") => FinishReason::ToolCall,
+        Some(other) => FinishReason::Other(other.to_string()),
+        None => FinishReason::Stop,
+    };
+
+    let usage = resp.usage_metadata.map(|u| UsageStats {
+        prompt_tokens: u.prompt_token_count.unwrap_or(0),
+        completion_tokens: u.candidates_token_count.unwrap_or(0),
+    });
+
+    Ok(LlmResponse {
+        text,
+        finish_reason,
+        usage,
+    })
+}
+
+/// Parse a GeminiResponse that may contain a function call.
+fn parse_tool_call_response(resp: GeminiResponse) -> Result<ToolCallResponse, CloudError> {
+    let candidate = resp
+        .candidates
+        .and_then(|c| c.into_iter().next())
+        .ok_or_else(|| CloudError::Provider {
+            http_status: 200,
+            message: "no candidates in response".to_string(),
+            retryable: false,
+        })?;
+
+    if let Some(content) = candidate.content {
+        for part in &content.parts {
+            if let Some(fc) = &part.function_call {
+                return Ok(ToolCallResponse::ToolCall {
+                    name: fc.name.clone(),
+                    arguments: fc.args.clone(),
+                });
+            }
+        }
+        let text = content
+            .parts
+            .into_iter()
+            .filter_map(|p| p.text)
+            .collect::<Vec<_>>()
+            .join("");
+        let llm_resp = LlmResponse {
+            text,
+            finish_reason: FinishReason::Stop,
+            usage: resp.usage_metadata.map(|u| UsageStats {
+                prompt_tokens: u.prompt_token_count.unwrap_or(0),
+                completion_tokens: u.candidates_token_count.unwrap_or(0),
+            }),
+        };
+        return Ok(ToolCallResponse::Text(llm_resp));
+    }
+
+    Err(CloudError::Provider {
+        http_status: 200,
+        message: "empty content in response".to_string(),
+        retryable: false,
+    })
+}
+
+/// Parse an SSE chunk from the streamGenerateContent endpoint.
+fn parse_sse_chunk(raw: &str) -> Vec<LlmStreamEvent> {
+    let mut events = Vec::new();
+    for line in raw.lines() {
+        let line = line.trim();
+        if let Some(data) = line.strip_prefix("data: ") {
+            if data == "[DONE]" {
+                events.push(LlmStreamEvent::Done(FinishReason::Stop));
+                continue;
+            }
+            if let Ok(chunk) = serde_json::from_str::<GeminiStreamChunk>(data) {
+                if let Some(candidates) = chunk.candidates {
+                    for candidate in candidates {
+                        if let Some(content) = candidate.content {
+                            for part in content.parts {
+                                if let Some(text) = part.text {
+                                    events.push(LlmStreamEvent::DeltaText(text));
+                                }
+                            }
+                        }
+                        if let Some(reason) = candidate.finish_reason {
+                            let fr = match reason.as_str() {
+                                "STOP" => FinishReason::Stop,
+                                "MAX_TOKENS" => FinishReason::Length,
+                                other => FinishReason::Other(other.to_string()),
+                            };
+                            events.push(LlmStreamEvent::Done(fr));
+                        }
+                    }
+                }
+                if let Some(usage) = chunk.usage_metadata {
+                    events.push(LlmStreamEvent::Usage(UsageStats {
+                        prompt_tokens: usage.prompt_token_count.unwrap_or(0),
+                        completion_tokens: usage.candidates_token_count.unwrap_or(0),
+                    }));
+                }
+            }
+        }
+    }
+    events
+}

--- a/rustcloud/src/gcp/gcp_apis/artificial_intelligence/mod.rs
+++ b/rustcloud/src/gcp/gcp_apis/artificial_intelligence/mod.rs
@@ -1,1 +1,2 @@
 pub mod gcp_automl;
+pub mod gcp_vertex_ai;

--- a/rustcloud/src/gcp/gcp_apis/database/gcp_bigquery.rs
+++ b/rustcloud/src/gcp/gcp_apis/database/gcp_bigquery.rs
@@ -72,9 +72,7 @@ impl BigQuery {
         Ok(json!({ "status": status.as_u16(), "body": body }))
     }
 
-    pub async fn list_datasets(
-        &self,
-    ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
+    pub async fn list_datasets(&self) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
         let url = format!("{}/projects/{}/datasets", self.base_url, self.project_id);
 
         let token = retrieve_token().await?;

--- a/rustcloud/src/gcp/gcp_apis/storage/gcp_storage.rs
+++ b/rustcloud/src/gcp/gcp_apis/storage/gcp_storage.rs
@@ -121,11 +121,12 @@ impl GoogleStorage {
             .send()
             .await?;
 
+        let status = resp.status().as_u16();
         let body = resp.text().await.unwrap_or_default();
         let mut response: HashMap<String, Value> = HashMap::new();
         response.insert(
             "status".to_string(),
-            Value::Number(resp.status().as_u16().into()),
+            Value::Number(status.into()),
         );
         response.insert("body".to_string(), Value::String(body));
 
@@ -149,12 +150,13 @@ impl GoogleStorage {
             .send()
             .await?;
 
+        let status = resp.status().as_u16();
         let body = resp.text().await.unwrap_or_default();
 
         let mut response = HashMap::new();
         response.insert(
             "status".to_string(),
-            Value::Number(resp.status().as_u16().into()),
+            Value::Number(status.into()),
         );
         response.insert("body".to_string(), Value::String(body));
 
@@ -243,12 +245,13 @@ impl GoogleStorage {
             .send()
             .await?;
 
+        let status = resp.status().as_u16();
         let body = resp.text().await.unwrap_or_default();
 
         let mut response = HashMap::new();
         response.insert(
             "status".to_string(),
-            Value::Number(resp.status().as_u16().into()),
+            Value::Number(status.into()),
         );
         response.insert("body".to_string(), Value::String(body));
 

--- a/rustcloud/src/gcp/types/artificial_intelligence/gcp_vertex_ai_types.rs
+++ b/rustcloud/src/gcp/types/artificial_intelligence/gcp_vertex_ai_types.rs
@@ -1,0 +1,195 @@
+use serde::{Deserialize, Serialize};
+
+// ─── Gemini API Request Types ───
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GeminiRequest {
+    pub contents: Vec<Content>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub system_instruction: Option<Content>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub generation_config: Option<GenerationConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Vec<GeminiTool>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Content {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+    pub parts: Vec<Part>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Part {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub function_call: Option<FunctionCall>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub function_response: Option<FunctionResponse>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FunctionCall {
+    pub name: String,
+    pub args: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FunctionResponse {
+    pub name: String,
+    pub response: serde_json::Value,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GenerationConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_output_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f32>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GeminiTool {
+    pub function_declarations: Vec<FunctionDeclaration>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FunctionDeclaration {
+    pub name: String,
+    pub description: String,
+    pub parameters: serde_json::Value,
+}
+
+// ─── Gemini API Response Types ───
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GeminiResponse {
+    pub candidates: Option<Vec<Candidate>>,
+    pub usage_metadata: Option<GeminiUsageMetadata>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Candidate {
+    pub content: Option<Content>,
+    pub finish_reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GeminiUsageMetadata {
+    pub prompt_token_count: Option<u32>,
+    pub candidates_token_count: Option<u32>,
+}
+
+// ─── Embedding Request/Response Types ───
+
+#[derive(Debug, Serialize)]
+pub struct EmbedRequest {
+    pub instances: Vec<EmbedInstance>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct EmbedInstance {
+    pub content: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct EmbedPredictResponse {
+    pub predictions: Vec<EmbedPrediction>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct EmbedPrediction {
+    pub embeddings: EmbedValues,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct EmbedValues {
+    pub values: Vec<f32>,
+}
+
+// ─── Vertex AI Dataset Types ───
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VertexDataset {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    pub display_name: String,
+    pub metadata_schema_uri: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportDataConfig {
+    pub gcs_source: GcsSource,
+    pub import_schema_uri: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GcsSource {
+    pub uris: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GcsDestination {
+    pub output_uri_prefix: String,
+}
+
+// ─── Vertex AI Endpoint Types ───
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateEndpointRequest {
+    pub display_name: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeployModelRequest {
+    pub deployed_model: DeployedModel,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeployedModel {
+    pub model: String,
+    pub display_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dedicated_resources: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub automatic_resources: Option<AutomaticResources>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AutomaticResources {
+    pub min_replica_count: u32,
+    pub max_replica_count: u32,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UndeployModelRequest {
+    pub deployed_model_id: String,
+}
+
+// ─── Streaming Types ───
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GeminiStreamChunk {
+    pub candidates: Option<Vec<Candidate>>,
+    pub usage_metadata: Option<GeminiUsageMetadata>,
+}

--- a/rustcloud/src/gcp/types/artificial_intelligence/mod.rs
+++ b/rustcloud/src/gcp/types/artificial_intelligence/mod.rs
@@ -1,1 +1,2 @@
 pub mod gcp_automl_types;
+pub mod gcp_vertex_ai_types;

--- a/rustcloud/src/gcp/types/database/mod.rs
+++ b/rustcloud/src/gcp/types/database/mod.rs
@@ -1,2 +1,2 @@
-pub mod gcp_bigtable_types;
 pub mod gcp_bigquery_types;
+pub mod gcp_bigtable_types;

--- a/rustcloud/src/main.rs
+++ b/rustcloud/src/main.rs
@@ -1,5 +1,5 @@
-mod tests;
 pub mod errors;
+mod tests;
 pub mod types {
     pub mod llm;
 }
@@ -7,12 +7,12 @@ pub mod traits {
     pub mod llm_provider;
     pub mod token_provider;
 }
-pub mod azure{
-    pub mod azure_apis{
-        pub mod auth{
+pub mod azure {
+    pub mod azure_apis {
+        pub mod auth {
             pub mod azure_auth;
         }
-        pub mod storage{
+        pub mod storage {
             pub mod azure_blob;
         }
     }
@@ -59,8 +59,8 @@ pub mod gcp {
             pub mod gcp_kubernetes;
         }
         pub mod database {
-            pub mod gcp_bigtable;
             pub mod gcp_bigquery;
+            pub mod gcp_bigtable;
         }
         pub mod network {
             pub mod gcp_dns;

--- a/rustcloud/src/tests/aws_bucket_operations.rs
+++ b/rustcloud/src/tests/aws_bucket_operations.rs
@@ -21,10 +21,21 @@ async fn create_test_bucket(client: &Client, bucket: &str) {
     let cfg = CreateBucketConfiguration::builder()
         .location_constraint(aws_sdk_s3::types::BucketLocationConstraint::UsWest2)
         .build();
-    create_bucket(client, BucketCannedAcl::PublicRead, bucket.to_string(), cfg,
-        None, None, None, None, None, None, None)
-        .await
-        .expect("Failed to create test bucket");
+    create_bucket(
+        client,
+        BucketCannedAcl::PublicRead,
+        bucket.to_string(),
+        cfg,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    .await
+    .expect("Failed to create test bucket");
 }
 
 #[tokio::test]
@@ -36,9 +47,19 @@ async fn test_create_bucket() {
         .build();
 
     let result = create_bucket(
-        &client, BucketCannedAcl::PublicRead, bucket.clone(), cfg,
-        None, None, None, None, None, None, None,
-    ).await;
+        &client,
+        BucketCannedAcl::PublicRead,
+        bucket.clone(),
+        cfg,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    .await;
 
     assert!(result.is_ok());
     delete(&client, bucket, None).await.ok();
@@ -61,9 +82,15 @@ async fn test_delete_object() {
     create_test_bucket(&client, bucket).await;
 
     let result = delete_object(
-        &client, bucket.to_string(), "test-object".to_string(),
-        None, None, None, None,
-    ).await;
+        &client,
+        bucket.to_string(),
+        "test-object".to_string(),
+        None,
+        None,
+        None,
+        None,
+    )
+    .await;
 
     assert!(result.is_ok());
     delete(&client, bucket.to_string(), None).await.ok();
@@ -116,8 +143,18 @@ async fn test_list_objects_v2() {
     let client = create_client().await;
     let bucket = "test-bucket".to_string();
 
-    let result = list_objects_v2(&client, bucket, None, None, Some(100), None, None, None, None)
-        .await;
+    let result = list_objects_v2(
+        &client,
+        bucket,
+        None,
+        None,
+        Some(100),
+        None,
+        None,
+        None,
+        None,
+    )
+    .await;
 
     assert!(result.is_ok());
 }

--- a/rustcloud/src/tests/aws_dynamodb_operations.rs
+++ b/rustcloud/src/tests/aws_dynamodb_operations.rs
@@ -149,11 +149,11 @@ async fn test_get_item() {
         &client,
         table_name,
         key,
-        None, // attributes_to_get
+        None,        // attributes_to_get
         Some(false), // consistent_read
-        None, // return_consumed_capacity
-        None, // projection_expression
-        None, // expression_attribute_names
+        None,        // return_consumed_capacity
+        None,        // projection_expression
+        None,        // expression_attribute_names
     )
     .await;
 
@@ -167,7 +167,10 @@ async fn test_put_item() {
     let table_name = "test-table".to_string();
     let mut item = HashMap::new();
     item.insert("id".to_string(), AttributeValue::S("test-id".to_string()));
-    item.insert("name".to_string(), AttributeValue::S("test-name".to_string()));
+    item.insert(
+        "name".to_string(),
+        AttributeValue::S("test-name".to_string()),
+    );
 
     let result = put_item(
         &client,
@@ -204,13 +207,13 @@ async fn test_update_item() {
         None, // expected
         None, // conditional_operator
         Some(ReturnValue::AllNew),
-        None, // return_consumed_capacity
-        None, // return_item_collection_metrics
+        None,                              // return_consumed_capacity
+        None,                              // return_item_collection_metrics
         Some("SET #n = :val".to_string()), // update_expression
-        None, // condition_expression
-        None, // expression_attribute_names
-        None, // expression_attribute_values
-        None, // return_values_on_condition_check_failure
+        None,                              // condition_expression
+        None,                              // expression_attribute_names
+        None,                              // expression_attribute_values
+        None,                              // return_values_on_condition_check_failure
     )
     .await;
 
@@ -257,9 +260,7 @@ async fn test_batch_write_item() {
         .build()
         .unwrap();
 
-    let write_request = WriteRequest::builder()
-        .put_request(put_request)
-        .build();
+    let write_request = WriteRequest::builder().put_request(put_request).build();
 
     let mut request_items = HashMap::new();
     request_items.insert("test-table".to_string(), vec![write_request]);

--- a/rustcloud/src/tests/aws_ec2_operations.rs
+++ b/rustcloud/src/tests/aws_ec2_operations.rs
@@ -98,7 +98,9 @@ async fn test_start_instance() {
     let client = create_client().await;
     let instance_id = create_test_instance(&client).await;
     wait_for_instance_state(&client, &instance_id, "running").await;
-    stop_instance(&client, &instance_id).await.expect("stop_instance failed");
+    stop_instance(&client, &instance_id)
+        .await
+        .expect("stop_instance failed");
     wait_for_instance_state(&client, &instance_id, "stopped").await;
     let result = start_instance(&client, &instance_id).await;
     cleanup_test_instance(&client, &instance_id).await;

--- a/rustcloud/src/tests/azure_blob_operations.rs
+++ b/rustcloud/src/tests/azure_blob_operations.rs
@@ -1,6 +1,5 @@
 use crate::azure::azure_apis::storage::azure_blob::AzureBlobClient;
 
-
 async fn create_client() -> AzureBlobClient {
     let account = std::env::var("AZURE_STORAGE_ACCOUNT").expect("AZURE_STORAGE_ACCOUNT not set");
 
@@ -9,7 +8,6 @@ async fn create_client() -> AzureBlobClient {
 
 #[tokio::test]
 async fn test_list_containers() {
-
     let client = create_client().await;
 
     let result = client.list_containers().await;
@@ -27,7 +25,6 @@ async fn test_list_containers() {
 
 #[tokio::test]
 async fn test_create_container() {
-    
     let client = create_client().await;
 
     let container = "test-container";
@@ -37,10 +34,8 @@ async fn test_create_container() {
     assert!(result.is_ok(), "{:?}", result);
 }
 
-
 #[tokio::test]
 async fn test_delete_container() {
-
     let client = create_client().await;
 
     let container = "test-container";

--- a/rustcloud/src/tests/gcp_bigquery_operations.rs
+++ b/rustcloud/src/tests/gcp_bigquery_operations.rs
@@ -57,7 +57,10 @@ async fn test_create_table() {
     let result = client
         .create_table("test_create_table_ds", "test_tbl", fields)
         .await;
-    client.delete_dataset("test_create_table_ds", true).await.ok();
+    client
+        .delete_dataset("test_create_table_ds", true)
+        .await
+        .ok();
     assert!(result.is_ok());
     let response = result.unwrap();
     assert_eq!(response["status"], 200);
@@ -67,10 +70,21 @@ async fn test_create_table() {
 async fn test_delete_table() {
     let client = create_client().await;
     client.create_dataset("test_delete_table_ds").await.ok();
-    let fields = vec![TableField { name: "id".to_string(), field_type: "INTEGER".to_string() }];
-    client.create_table("test_delete_table_ds", "test_tbl", fields).await.ok();
-    let result = client.delete_table("test_delete_table_ds", "test_tbl").await;
-    client.delete_dataset("test_delete_table_ds", true).await.ok();
+    let fields = vec![TableField {
+        name: "id".to_string(),
+        field_type: "INTEGER".to_string(),
+    }];
+    client
+        .create_table("test_delete_table_ds", "test_tbl", fields)
+        .await
+        .ok();
+    let result = client
+        .delete_table("test_delete_table_ds", "test_tbl")
+        .await;
+    client
+        .delete_dataset("test_delete_table_ds", true)
+        .await
+        .ok();
     assert!(result.is_ok());
     let response = result.unwrap();
     assert_eq!(response["status"], 204);
@@ -81,7 +95,10 @@ async fn test_list_tables() {
     let client = create_client().await;
     client.create_dataset("test_list_tables_ds").await.ok();
     let result = client.list_tables("test_list_tables_ds").await;
-    client.delete_dataset("test_list_tables_ds", true).await.ok();
+    client
+        .delete_dataset("test_list_tables_ds", true)
+        .await
+        .ok();
     assert!(result.is_ok());
     let response = result.unwrap();
     assert_eq!(response["status"], 200);

--- a/rustcloud/src/tests/gcp_vertex_ai_operations.rs
+++ b/rustcloud/src/tests/gcp_vertex_ai_operations.rs
@@ -1,0 +1,241 @@
+use crate::gcp::gcp_apis::artificial_intelligence::gcp_vertex_ai::VertexAI;
+use crate::traits::llm_provider::LlmProvider;
+use crate::types::llm::{LlmRequest, Message, ModelRef, ToolDefinition};
+
+fn create_client() -> VertexAI {
+    VertexAI::new("your_project_id", "us-central1")
+}
+
+// ─── Dataset Management Tests ───
+
+#[tokio::test]
+async fn test_create_dataset() {
+    let client = create_client();
+
+    let display_name = "test-dataset";
+    let schema_uri = "gs://google-cloud-aiplatform/schema/dataset/metadata/tabular_1.0.0.yaml";
+
+    let result = client.create_dataset(display_name, schema_uri).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_get_dataset() {
+    let client = create_client();
+
+    let dataset_id = "your_dataset_id";
+
+    let result = client.get_dataset(dataset_id).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_import_data() {
+    let client = create_client();
+
+    let dataset_id = "your_dataset_id";
+    let gcs_uris = vec!["gs://your_bucket/your_file.csv".to_string()];
+    let schema_uri = "gs://google-cloud-aiplatform/schema/dataset/ioformat/tabular_1.0.0.yaml";
+
+    let result = client.import_data(dataset_id, gcs_uris, schema_uri).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_export_dataset() {
+    let client = create_client();
+
+    let dataset_id = "your_dataset_id";
+    let gcs_uri = "gs://your_bucket/your_export_path/";
+
+    let result = client.export_dataset(dataset_id, gcs_uri).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_delete_dataset() {
+    let client = create_client();
+
+    let dataset_id = "your_dataset_id";
+
+    let result = client.delete_dataset(dataset_id).await;
+    assert!(result.is_ok());
+}
+
+// ─── Model Management Tests ───
+
+#[tokio::test]
+async fn test_list_models() {
+    let client = create_client();
+
+    let result = client.list_models().await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_get_model() {
+    let client = create_client();
+
+    let model_id = "your_model_id";
+
+    let result = client.get_model(model_id).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_delete_model() {
+    let client = create_client();
+
+    let model_id = "your_model_id";
+
+    let result = client.delete_model(model_id).await;
+    assert!(result.is_ok());
+}
+
+// ─── Endpoint Management Tests ───
+
+#[tokio::test]
+async fn test_create_endpoint() {
+    let client = create_client();
+
+    let display_name = "test-endpoint";
+
+    let result = client.create_endpoint(display_name).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_deploy_model() {
+    let client = create_client();
+
+    let endpoint_id = "your_endpoint_id";
+    let model_resource_name = "projects/your_project/locations/us-central1/models/your_model";
+    let display_name = "deployed-model";
+
+    let result = client
+        .deploy_model(endpoint_id, model_resource_name, display_name)
+        .await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_undeploy_model() {
+    let client = create_client();
+
+    let endpoint_id = "your_endpoint_id";
+    let deployed_model_id = "your_deployed_model_id";
+
+    let result = client
+        .undeploy_model(endpoint_id, deployed_model_id)
+        .await;
+    assert!(result.is_ok());
+}
+
+// ─── LlmProvider Trait Tests ───
+
+#[tokio::test]
+async fn test_generate() {
+    let client = create_client();
+
+    let req = LlmRequest {
+        model: ModelRef::Provider("gemini-1.5-flash".to_string()),
+        messages: vec![Message {
+            role: "user".to_string(),
+            content: "Hello, Gemini! Say hello back in one sentence.".to_string(),
+        }],
+        max_tokens: Some(100),
+        temperature: Some(0.7),
+        system_prompt: None,
+    };
+
+    let result = client.generate(req).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_generate_with_system_prompt() {
+    let client = create_client();
+
+    let req = LlmRequest {
+        model: ModelRef::Provider("gemini-1.5-flash".to_string()),
+        messages: vec![Message {
+            role: "user".to_string(),
+            content: "What is 2+2?".to_string(),
+        }],
+        max_tokens: Some(50),
+        temperature: Some(0.0),
+        system_prompt: Some("You are a math tutor. Answer concisely.".to_string()),
+    };
+
+    let result = client.generate(req).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_embed() {
+    let client = create_client();
+
+    let texts = vec![
+        "Hello world".to_string(),
+        "Rust is great".to_string(),
+    ];
+
+    let result = client.embed(texts).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_generate_with_tools() {
+    let client = create_client();
+
+    let req = LlmRequest {
+        model: ModelRef::Provider("gemini-1.5-flash".to_string()),
+        messages: vec![Message {
+            role: "user".to_string(),
+            content: "What is the weather in London?".to_string(),
+        }],
+        max_tokens: Some(100),
+        temperature: None,
+        system_prompt: None,
+    };
+
+    let tools = vec![ToolDefinition {
+        name: "get_weather".to_string(),
+        description: "Get current weather for a location".to_string(),
+        parameters: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "location": {
+                    "type": "string",
+                    "description": "The city name"
+                }
+            },
+            "required": ["location"]
+        }),
+    }];
+
+    let result = client.generate_with_tools(req, tools).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_logical_model_ref() {
+    let client = create_client();
+
+    let req = LlmRequest {
+        model: ModelRef::Logical {
+            family: "gemini".to_string(),
+            tier: Some("flash".to_string()),
+        },
+        messages: vec![Message {
+            role: "user".to_string(),
+            content: "Hello!".to_string(),
+        }],
+        max_tokens: Some(50),
+        temperature: None,
+        system_prompt: None,
+    };
+
+    let result = client.generate(req).await;
+    assert!(result.is_ok());
+}

--- a/rustcloud/src/tests/mod.rs
+++ b/rustcloud/src/tests/mod.rs
@@ -1,4 +1,3 @@
-mod azure_blob_operations;
 mod aws_archival_operations;
 mod aws_block_operations;
 mod aws_bucket_operations;
@@ -11,9 +10,10 @@ mod aws_iam_operations;
 mod aws_kms_operations;
 mod aws_loadbalancer_operations;
 mod aws_monitoring_operations;
+mod azure_blob_operations;
 mod gcp_automl_operations;
-mod gcp_bigtable_operations;
 mod gcp_bigquery_operations;
+mod gcp_bigtable_operations;
 mod gcp_compute_operations;
 mod gcp_dns_operations;
 mod gcp_kubernetes_operations;


### PR DESCRIPTION
closes  #53 



 Summary--->

Migrates GCP AI module from deprecated **AutoML** to **Vertex AI** and implements the `LlmProvider` trait with Gemini model support.


Problem--->

Google is sunsetting standalone AutoML in favor of Vertex AI. Our `gcp_automl.rs` module uses deprecated endpoints that will stop working.



## Solution

- Created `VertexAI` struct implementing full `LlmProvider` trait
- Migrated all dataset/model management methods to Vertex AI endpoints  
- Added Gemini support: text generation, streaming, embeddings, function calling
- Marked old `AutoML` struct as `#[deprecated]` (non-breaking)


Changes--->

**New files:**
- `gcp_vertex_ai.rs` - Core implementation with LlmProvider trait
- `gcp_vertex_ai_types.rs` - 19 serde types for Vertex AI/Gemini API
- `gcp_vertex_ai_operations.rs` - 16 test cases

**Modified:**
- `Cargo.toml` - Added reqwest `json`/`stream` features
- `mod.rs` files - Module registration
- `gcp_automl.rs` - Added deprecation warning


Checklist--->
- Implements LlmProvider trait for GCP
 -Migrates AutoML methods to Vertex AI
 -Includes test coverage
- Non-breaking (old code compiles with warning)
 -Passes cargo fmt