### PR TITLE
feat: Add Fallback-Provider for high-availability GenAI workloads

### DIFF
--- a/rustcloud/src/gcp/gcp_apis/storage/gcp_storage.rs
+++ b/rustcloud/src/gcp/gcp_apis/storage/gcp_storage.rs
@@ -121,11 +121,13 @@ impl GoogleStorage {
             .send()
             .await?;
 
+        // Extract status before consuming response with text()
+        let status = resp.status().as_u16();
         let body = resp.text().await.unwrap_or_default();
         let mut response: HashMap<String, Value> = HashMap::new();
         response.insert(
             "status".to_string(),
-            Value::Number(resp.status().as_u16().into()),
+            Value::Number(status.into()),
         );
         response.insert("body".to_string(), Value::String(body));
 
@@ -149,12 +151,14 @@ impl GoogleStorage {
             .send()
             .await?;
 
+        // Extract status before consuming response with text()
+        let status = resp.status().as_u16();
         let body = resp.text().await.unwrap_or_default();
 
         let mut response = HashMap::new();
         response.insert(
             "status".to_string(),
-            Value::Number(resp.status().as_u16().into()),
+            Value::Number(status.into()),
         );
         response.insert("body".to_string(), Value::String(body));
 
@@ -243,12 +247,14 @@ impl GoogleStorage {
             .send()
             .await?;
 
+        // Extract status before consuming response with text()
+        let status = resp.status().as_u16();
         let body = resp.text().await.unwrap_or_default();
 
         let mut response = HashMap::new();
         response.insert(
             "status".to_string(),
-            Value::Number(resp.status().as_u16().into()),
+            Value::Number(status.into()),
         );
         response.insert("body".to_string(), Value::String(body));
 

--- a/rustcloud/src/main.rs
+++ b/rustcloud/src/main.rs
@@ -7,6 +7,9 @@ pub mod traits {
     pub mod llm_provider;
     pub mod token_provider;
 }
+pub mod providers {
+    pub mod fallback;
+}
 pub mod azure{
     pub mod azure_apis{
         pub mod auth{

--- a/rustcloud/src/providers/fallback.rs
+++ b/rustcloud/src/providers/fallback.rs
@@ -1,0 +1,324 @@
+//! Adaptive Fallback Provider for High-Availability GenAI Workloads
+//!
+//! This module provides a `FallbackProvider` that wraps multiple LLM providers
+//! and automatically falls back to the next provider when transient errors occur.
+
+use async_trait::async_trait;
+
+use crate::errors::CloudError;
+use crate::traits::llm_provider::{LlmProvider, LlmStream};
+use crate::types::llm::{
+    EmbedResponse, LlmRequest, LlmResponse, ToolCallResponse, ToolDefinition,
+};
+
+/// Determines if a `CloudError` is transient and should trigger a fallback.
+///
+/// This function detects:
+/// - Explicit rate limit errors (`CloudError::RateLimit`)
+/// - AWS Bedrock: `ThrottlingException` or `InternalServerException`
+/// - GCP Vertex AI: HTTP 429 (RESOURCE_EXHAUSTED) or 500 (INTERNAL_SERVER_ERROR)
+/// - Provider errors marked as retryable
+/// - Transient network errors
+fn is_retryable(error: &CloudError) -> bool {
+    match error {
+        // Explicit rate limit - always retryable
+        CloudError::RateLimit { .. } => true,
+
+        // Provider errors - check http_status and message
+        CloudError::Provider {
+            http_status,
+            message,
+            retryable,
+        } => {
+            // If explicitly marked as retryable
+            if *retryable {
+                return true;
+            }
+
+            // GCP Vertex AI: HTTP 429 (RESOURCE_EXHAUSTED)
+            if *http_status == 429 {
+                return true;
+            }
+
+            // GCP Vertex AI: HTTP 500 (INTERNAL_SERVER_ERROR)
+            if *http_status == 500 {
+                return true;
+            }
+
+            // AWS Bedrock: ThrottlingException
+            if message.contains("ThrottlingException") {
+                return true;
+            }
+
+            // AWS Bedrock: InternalServerException
+            if message.contains("InternalServerException") {
+                return true;
+            }
+
+            false
+        }
+
+        // Network errors are typically transient
+        CloudError::Network { .. } => true,
+
+        // Auth errors are not retryable - indicates misconfiguration
+        CloudError::Auth { .. } => false,
+
+        // Serialization errors are not retryable - indicates code bug
+        CloudError::Serialization { .. } => false,
+
+        // Unsupported features won't become supported by retrying
+        CloudError::Unsupported { .. } => false,
+    }
+}
+
+/// A resilient LLM provider that wraps multiple providers and automatically
+/// falls back to the next provider when transient errors occur.
+///
+/// # Example
+///
+/// ```ignore
+/// use rustcloud::providers::FallbackProvider;
+///
+/// let fallback = FallbackProvider::new(vec![
+///     Box::new(aws_bedrock_provider),
+///     Box::new(gcp_vertex_provider),
+///     Box::new(azure_openai_provider),
+/// ]);
+///
+/// // If AWS fails with rate limit, automatically tries GCP, then Azure
+/// let response = fallback.generate(request).await?;
+/// ```
+pub struct FallbackProvider {
+    providers: Vec<Box<dyn LlmProvider + Send + Sync>>,
+}
+
+impl FallbackProvider {
+    /// Creates a new `FallbackProvider` with the given list of providers.
+    ///
+    /// Providers are tried in order - the first provider is the primary,
+    /// subsequent providers are fallbacks used when transient errors occur.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the providers list is empty.
+    pub fn new(providers: Vec<Box<dyn LlmProvider + Send + Sync>>) -> Self {
+        assert!(!providers.is_empty(), "FallbackProvider requires at least one provider");
+        Self { providers }
+    }
+
+    /// Returns the number of providers in the fallback chain.
+    pub fn provider_count(&self) -> usize {
+        self.providers.len()
+    }
+}
+
+#[async_trait]
+impl LlmProvider for FallbackProvider {
+    async fn generate(&self, req: LlmRequest) -> Result<LlmResponse, CloudError> {
+        let mut last_error: Option<CloudError> = None;
+
+        for (idx, provider) in self.providers.iter().enumerate() {
+            let request = req.clone();
+
+            match provider.generate(request).await {
+                Ok(response) => return Ok(response),
+                Err(err) => {
+                    let is_last = idx == self.providers.len() - 1;
+
+                    if is_last || !is_retryable(&err) {
+                        // Either this is the last provider, or the error is not retryable
+                        return Err(err);
+                    }
+
+                    // Store error and continue to next provider
+                    last_error = Some(err);
+                }
+            }
+        }
+
+        // This should never be reached due to the loop logic,
+        // but handle it just in case
+        Err(last_error.unwrap_or_else(|| CloudError::Provider {
+            http_status: 500,
+            message: "No providers available".to_string(),
+            retryable: false,
+        }))
+    }
+
+    async fn stream(&self, req: LlmRequest) -> Result<LlmStream, CloudError> {
+        let mut last_error: Option<CloudError> = None;
+
+        for (idx, provider) in self.providers.iter().enumerate() {
+            let request = req.clone();
+
+            match provider.stream(request).await {
+                Ok(stream) => return Ok(stream),
+                Err(err) => {
+                    let is_last = idx == self.providers.len() - 1;
+
+                    if is_last || !is_retryable(&err) {
+                        return Err(err);
+                    }
+
+                    last_error = Some(err);
+                }
+            }
+        }
+
+        Err(last_error.unwrap_or_else(|| CloudError::Provider {
+            http_status: 500,
+            message: "No providers available".to_string(),
+            retryable: false,
+        }))
+    }
+
+    async fn embed(&self, texts: Vec<String>) -> Result<EmbedResponse, CloudError> {
+        let mut last_error: Option<CloudError> = None;
+
+        for (idx, provider) in self.providers.iter().enumerate() {
+            let texts_clone = texts.clone();
+
+            match provider.embed(texts_clone).await {
+                Ok(response) => return Ok(response),
+                Err(err) => {
+                    let is_last = idx == self.providers.len() - 1;
+
+                    if is_last || !is_retryable(&err) {
+                        return Err(err);
+                    }
+
+                    last_error = Some(err);
+                }
+            }
+        }
+
+        Err(last_error.unwrap_or_else(|| CloudError::Provider {
+            http_status: 500,
+            message: "No providers available".to_string(),
+            retryable: false,
+        }))
+    }
+
+    async fn generate_with_tools(
+        &self,
+        req: LlmRequest,
+        tools: Vec<ToolDefinition>,
+    ) -> Result<ToolCallResponse, CloudError> {
+        let mut last_error: Option<CloudError> = None;
+
+        for (idx, provider) in self.providers.iter().enumerate() {
+            let request = req.clone();
+            let tools_clone = tools.clone();
+
+            match provider.generate_with_tools(request, tools_clone).await {
+                Ok(response) => return Ok(response),
+                Err(err) => {
+                    let is_last = idx == self.providers.len() - 1;
+
+                    if is_last || !is_retryable(&err) {
+                        return Err(err);
+                    }
+
+                    last_error = Some(err);
+                }
+            }
+        }
+
+        Err(last_error.unwrap_or_else(|| CloudError::Provider {
+            http_status: 500,
+            message: "No providers available".to_string(),
+            retryable: false,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_rate_limit() {
+        let error = CloudError::RateLimit { retry_after: Some(30) };
+        assert!(is_retryable(&error));
+
+        let error = CloudError::RateLimit { retry_after: None };
+        assert!(is_retryable(&error));
+    }
+
+    #[test]
+    fn test_is_retryable_http_429() {
+        let error = CloudError::Provider {
+            http_status: 429,
+            message: "RESOURCE_EXHAUSTED".to_string(),
+            retryable: false,
+        };
+        assert!(is_retryable(&error));
+    }
+
+    #[test]
+    fn test_is_retryable_http_500() {
+        let error = CloudError::Provider {
+            http_status: 500,
+            message: "INTERNAL_SERVER_ERROR".to_string(),
+            retryable: false,
+        };
+        assert!(is_retryable(&error));
+    }
+
+    #[test]
+    fn test_is_retryable_aws_throttling() {
+        let error = CloudError::Provider {
+            http_status: 400,
+            message: "ThrottlingException: Rate exceeded".to_string(),
+            retryable: false,
+        };
+        assert!(is_retryable(&error));
+    }
+
+    #[test]
+    fn test_is_retryable_aws_internal() {
+        let error = CloudError::Provider {
+            http_status: 400,
+            message: "InternalServerException: Service unavailable".to_string(),
+            retryable: false,
+        };
+        assert!(is_retryable(&error));
+    }
+
+    #[test]
+    fn test_is_retryable_explicit_flag() {
+        let error = CloudError::Provider {
+            http_status: 503,
+            message: "Service temporarily unavailable".to_string(),
+            retryable: true,
+        };
+        assert!(is_retryable(&error));
+    }
+
+    #[test]
+    fn test_not_retryable_auth() {
+        let error = CloudError::Auth {
+            message: "Invalid credentials".to_string(),
+        };
+        assert!(!is_retryable(&error));
+    }
+
+    #[test]
+    fn test_not_retryable_unsupported() {
+        let error = CloudError::Unsupported {
+            feature: "streaming",
+        };
+        assert!(!is_retryable(&error));
+    }
+
+    #[test]
+    fn test_not_retryable_generic_provider_error() {
+        let error = CloudError::Provider {
+            http_status: 400,
+            message: "Bad request: invalid model".to_string(),
+            retryable: false,
+        };
+        assert!(!is_retryable(&error));
+    }
+}

--- a/rustcloud/src/providers/mod.rs
+++ b/rustcloud/src/providers/mod.rs
@@ -1,0 +1,3 @@
+pub mod fallback;
+
+pub use fallback::FallbackProvider;

--- a/rustcloud/src/tests/gcp_bigtable_operations.rs
+++ b/rustcloud/src/tests/gcp_bigtable_operations.rs
@@ -50,13 +50,14 @@ async fn test_create_tables() {
     let parent = "projects/your_project_id/instances/your_instance_id";
     let table_id = "your_table_id";
     let table = Table {
-        // Populate Table struct fields
+        granularity: "MILLIS".to_string(),
+        name: "your_table_id".to_string(),
     };
     let initial_splits = vec![InitialSplits {
-            // Populate InitialSplits struct fields
-        }];
+        key: "split_key".to_string(),
+    }];
     let cluster_states = ClusterStates {
-        // Populate ClusterStates struct fields
+        replication_state: "READY".to_string(),
     };
 
     let result = client


### PR DESCRIPTION
closes #58 

 ### The Problem

 **1: GenAI Workloads Are Fragile**

-Cloud providers fail. A lot. Here's what happens in production:
Rate limits, transient errors, and internal server hiccups are inevitable when working with LLM APIs. Currently, RustCloud has no        resilience mechanism—if your primary provider fails, your entire application fails.

 **2: Silent Bugs in GCP Storage**

While implementing the fallback provider, I discovered the codebase wouldn't even compile due to a classic Rust ownership bug:
This bug existed in 3 functions, silently waiting to break production.

### The Solution

**Part 1: Fallback-Provider**
I built an Adaptive Fallback Provider that wraps multiple LLM providers and intelligently routes around failures:
User Request → AWS Bedrock → 💥 Rate Limit
                    ↓
              GCP Vertex AI → 💥 Internal Error  
                    ↓
              Azure OpenAI → ✅ Success!

**Part 2: Ownership Bug Fixes** 
Fixed the "use after move" anti-pattern by extracting data before consumption.
## 📁 Files Changed

| File | Change Type | Description |
|------|-------------|-------------|
| `src/providers/mod.rs` | ✨ NEW | Module exports for providers |
| `src/providers/fallback.rs` | ✨ NEW | FallbackProvider + 9 unit tests |
| `src/main.rs` | 📝 Modified | Registered providers module |
| `src/gcp/gcp_apis/storage/gcp_storage.rs` | 🐛 BUGFIX | Fixed 3 ownership violations |
| `src/tests/gcp_bigtable_operations.rs` | 🐛 BUGFIX | Fixed incomplete struct initialization |

## 🔗 How The Fixes Connect


| Step | Component | Issue | Resolution |
|------|-----------|-------|------------|
| 1 | **FallbackProvider (NEW)** | Needed to implement new feature | Created adaptive fallback mechanism |
| 2 | **cargo check** | Revealed hidden bugs in codebase | Identified 2 blocking issues |
| 3 | **gcp_storage.rs** | 3 ownership bugs (use after move) | Extracted status before consuming response |
| 4 | **bigtable_test.rs** | Missing required struct fields | Added proper field initialization |
| 5 | **FallbackProvider** | New feature implementation | Implemented all 4 LlmProvider methods |

**Connection Flow:**

| From | To | Relationship |
|------|----|--------------|
| FallbackProvider | cargo check | Triggered compilation |
| cargo check | gcp_storage.rs | Exposed ownership bugs |
| cargo check | bigtable_test.rs | Exposed incomplete structs |
| All Fixes | ✅ Clean Build | Enabled tests to run |



### This PR addresses Issue: Adaptive Fallback Provider for High-Availability GenAI Workloads

Checklist:

_1.  Implements FallbackProvider struct in rustcloud::providers::fallback
2.  Wraps Vec<Box<dyn LlmProvider + Send + Sync>>
3.  Implements all 4 LlmProvider trait methods
4.  Smart error detection for AWS Bedrock & GCP Vertex AI
5.  Handles async/await correctly with Tokio
6.  Returns library's CloudError type
7.  Unit tests for error classification
8.  Fixed pre-existing compilation blockers_


**This pr solves the issue that can be faced in future in pr #55 
and adds Add Fallback-Provider for high-availability GenAI workloads**