### PR TITLE
fix(digitalocean): avoid panic when serializing create requests

### DIFF
--- a/rustcloud/src/digiocean/digiocean_apis/compute/digiocean_droplet.rs
+++ b/rustcloud/src/digiocean/digiocean_apis/compute/digiocean_droplet.rs
@@ -22,14 +22,13 @@ impl Droplet {
         request: HashMap<String, Value>,
     ) -> Result<HashMap<String, Value>, reqwest::Error> {
         let url = format!("{}/droplets", self.base_url);
-        let body = serde_json::to_string(&request).unwrap();
 
         let resp = self
             .client
             .post(&url)
             .header("Content-Type", "application/json")
             .header(AUTHORIZATION, format!("Bearer {}", self.token))
-            .body(body)
+            .json(&request)
             .send()
             .await?;
 

--- a/rustcloud/src/digiocean/digiocean_apis/dns/digiocean_dns.rs
+++ b/rustcloud/src/digiocean/digiocean_apis/dns/digiocean_dns.rs
@@ -22,14 +22,13 @@ impl DigiOceanDns {
         request: HashMap<String, Value>,
     ) -> Result<HashMap<String, Value>, reqwest::Error> {
         let url = format!("{}/domains", self.base_url);
-        let body = serde_json::to_string(&request).unwrap();
 
         let resp = self
             .client
             .post(&url)
             .header("Content-Type", "application/json")
             .header(AUTHORIZATION, format!("Bearer {}", self.token))
-            .body(body)
+            .json(&request)
             .send()
             .await?;
 

--- a/rustcloud/src/digiocean/digiocean_apis/network/digiocean_loadbalancer.rs
+++ b/rustcloud/src/digiocean/digiocean_apis/network/digiocean_loadbalancer.rs
@@ -22,14 +22,13 @@ impl DigiOceanLoadBalancer {
         request: HashMap<String, Value>,
     ) -> Result<HashMap<String, Value>, reqwest::Error> {
         let url = format!("{}/load_balancers", self.base_url);
-        let body = serde_json::to_string(&request).unwrap();
 
         let resp = self
             .client
             .post(&url)
             .header("Content-Type", "application/json")
             .header(AUTHORIZATION, format!("Bearer {}", self.token))
-            .body(body)
+            .json(&request)
             .send()
             .await?;
 

--- a/rustcloud/src/digiocean/digiocean_apis/storage/digiocean_storage.rs
+++ b/rustcloud/src/digiocean/digiocean_apis/storage/digiocean_storage.rs
@@ -22,14 +22,13 @@ impl DigiOceanStorage {
         request: HashMap<String, Value>,
     ) -> Result<HashMap<String, Value>, reqwest::Error> {
         let url = format!("{}/volumes", self.base_url);
-        let body = serde_json::to_string(&request).unwrap();
 
         let resp = self
             .client
             .post(&url)
             .header("Content-Type", "application/json")
             .header(AUTHORIZATION, format!("Bearer {}", self.token))
-            .body(body)
+            .json(&request)
             .send()
             .await?;
 


### PR DESCRIPTION
Replaces manual serde_json::to_string(...).unwrap() calls in DigitalOcean create operations with reqwest .json(&request) payload handling. This removes panic paths while preserving request behavior.