### PR TITLE
fix(gcp): normalize compute request keys and keep legacy aliases

### DIFF
--- a/examples/gcp/compute/compute_engine.md
+++ b/examples/gcp/compute/compute_engine.md
@@ -35,8 +35,8 @@ async fn main() {
     let gce_client = GCE::new();
 
     let mut request = HashMap::new();
-    request.insert("projectid".to_string(), json!("my-gcp-project"));
-    request.insert("Zone".to_string(), json!("us-central1-a"));
+    request.insert("project_id".to_string(), json!("my-gcp-project"));
+    request.insert("zone".to_string(), json!("us-central1-a"));
     request.insert("Name".to_string(), json!("my-instance"));
     request.insert("MachineType".to_string(), json!("n1-standard-1"));
     // Add other parameters as needed
@@ -57,8 +57,8 @@ async fn main() {
     let gce_client = GCE::new();
 
     let mut request = HashMap::new();
-    request.insert("projectid".to_string(), "my-gcp-project".to_string());
-    request.insert("Zone".to_string(), "us-central1-a".to_string());
+    request.insert("project_id".to_string(), "my-gcp-project".to_string());
+    request.insert("zone".to_string(), "us-central1-a".to_string());
     request.insert("instance".to_string(), "my-instance".to_string());
 
     let response = gce_client.start_node(request).await.unwrap();
@@ -77,8 +77,8 @@ async fn main() {
     let gce_client = GCE::new();
 
     let mut request = HashMap::new();
-    request.insert("projectid".to_string(), "my-gcp-project".to_string());
-    request.insert("Zone".to_string(), "us-central1-a".to_string());
+    request.insert("project_id".to_string(), "my-gcp-project".to_string());
+    request.insert("zone".to_string(), "us-central1-a".to_string());
     request.insert("instance".to_string(), "my-instance".to_string());
 
     let response = gce_client.stop_node(request).await.unwrap();
@@ -97,8 +97,8 @@ async fn main() {
     let gce_client = GCE::new();
 
     let mut request = HashMap::new();
-    request.insert("projectid".to_string(), "my-gcp-project".to_string());
-    request.insert("Zone".to_string(), "us-central1-a".to_string());
+    request.insert("project_id".to_string(), "my-gcp-project".to_string());
+    request.insert("zone".to_string(), "us-central1-a".to_string());
     request.insert("instance".to_string(), "my-instance".to_string());
 
     let response = gce_client.delete_node(request).await.unwrap();
@@ -117,8 +117,8 @@ async fn main() {
     let gce_client = GCE::new();
 
     let mut request = HashMap::new();
-    request.insert("projectid".to_string(), "my-gcp-project".to_string());
-    request.insert("Zone".to_string(), "us-central1-a".to_string());
+    request.insert("project_id".to_string(), "my-gcp-project".to_string());
+    request.insert("zone".to_string(), "us-central1-a".to_string());
     request.insert("instance".to_string(), "my-instance".to_string());
 
     let response = gce_client.reboot_node(request).await.unwrap();
@@ -137,8 +137,8 @@ async fn main() {
     let gce_client = GCE::new();
 
     let mut request = HashMap::new();
-    request.insert("projectid".to_string(), "my-gcp-project".to_string());
-    request.insert("Zone".to_string(), "us-central1-a".to_string());
+    request.insert("project_id".to_string(), "my-gcp-project".to_string());
+    request.insert("zone".to_string(), "us-central1-a".to_string());
 
     let response = gce_client.list_node(request).await.unwrap();
     println!("{:?}", response);

--- a/rustcloud/src/gcp/gcp_apis/compute/gcp_compute_engine.rs
+++ b/rustcloud/src/gcp/gcp_apis/compute/gcp_compute_engine.rs
@@ -1,12 +1,26 @@
 use reqwest::{header::AUTHORIZATION, Client, Method};
 use serde_json::json;
 use std::collections::HashMap;
+use std::io;
 
 use crate::gcp::gcp_apis::auth::gcp_auth::retrieve_token;
 
 pub struct GCE {
     client: Client,
     base_url: String,
+}
+
+fn get_request_value<'a>(
+    request: &'a HashMap<String, String>,
+    keys: &[&str],
+    field_name: &str,
+) -> Result<&'a String, Box<dyn std::error::Error>> {
+    keys.iter().find_map(|key| request.get(*key)).ok_or_else(|| {
+        Box::new(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("missing required field: {field_name}"),
+        )) as Box<dyn std::error::Error>
+    })
 }
 
 impl GCE {
@@ -27,9 +41,15 @@ impl GCE {
 
         for (key, value) in request {
             match key.as_str() {
-                "projectid" => project_id = value.as_str().unwrap().to_string(),
-                "Zone" => {
-                    zone = value.as_str().unwrap().to_string();
+                "projectid" | "project_id" => {
+                    if let Some(project) = value.as_str() {
+                        project_id = project.to_string();
+                    }
+                }
+                "Zone" | "zone" => {
+                    if let Some(region_zone) = value.as_str() {
+                        zone = region_zone.to_string();
+                    }
                     gce_instance.insert("Zone", value);
                 }
                 "selfLink" => {
@@ -157,7 +177,20 @@ impl GCE {
             }
         }
 
-        let gce_instance_json = serde_json::to_string(&gce_instance).unwrap();
+        if project_id.is_empty() {
+            return Err(Box::new(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "missing required field: project_id",
+            )));
+        }
+        if zone.is_empty() {
+            return Err(Box::new(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "missing required field: zone",
+            )));
+        }
+
+        let gce_instance_json = serde_json::to_string(&gce_instance)?;
         let url = format!(
             "{}/projects/{}/zones/{}/instances",
             self.base_url, project_id, zone
@@ -187,9 +220,9 @@ impl GCE {
         &self,
         request: HashMap<String, String>,
     ) -> Result<HashMap<String, String>, Box<dyn std::error::Error>> {
-        let project_id = request.get("projectid").unwrap();
-        let zone = request.get("Zone").unwrap();
-        let instance = request.get("instance").unwrap();
+        let project_id = get_request_value(&request, &["project_id", "projectid"], "project_id")?;
+        let zone = get_request_value(&request, &["zone", "Zone"], "zone")?;
+        let instance = get_request_value(&request, &["instance"], "instance")?;
         let url = format!(
             "{}/projects/{}/zones/{}/instances/{}/start",
             self.base_url, project_id, zone, instance
@@ -218,9 +251,9 @@ impl GCE {
         &self,
         request: HashMap<String, String>,
     ) -> Result<HashMap<String, String>, Box<dyn std::error::Error>> {
-        let project_id = request.get("projectid").unwrap();
-        let zone = request.get("Zone").unwrap();
-        let instance = request.get("instance").unwrap();
+        let project_id = get_request_value(&request, &["project_id", "projectid"], "project_id")?;
+        let zone = get_request_value(&request, &["zone", "Zone"], "zone")?;
+        let instance = get_request_value(&request, &["instance"], "instance")?;
         let url = format!(
             "{}/projects/{}/zones/{}/instances/{}/stop",
             self.base_url, project_id, zone, instance
@@ -249,9 +282,9 @@ impl GCE {
         &self,
         request: HashMap<String, String>,
     ) -> Result<HashMap<String, String>, Box<dyn std::error::Error>> {
-        let project_id = request.get("projectid").unwrap();
-        let zone = request.get("Zone").unwrap();
-        let instance = request.get("instance").unwrap();
+        let project_id = get_request_value(&request, &["project_id", "projectid"], "project_id")?;
+        let zone = get_request_value(&request, &["zone", "Zone"], "zone")?;
+        let instance = get_request_value(&request, &["instance"], "instance")?;
         let url = format!(
             "{}/projects/{}/zones/{}/instances/{}",
             self.base_url, project_id, zone, instance
@@ -280,9 +313,9 @@ impl GCE {
         &self,
         request: HashMap<String, String>,
     ) -> Result<HashMap<String, String>, Box<dyn std::error::Error>> {
-        let project_id = request.get("projectid").unwrap();
-        let zone = request.get("Zone").unwrap();
-        let instance = request.get("instance").unwrap();
+        let project_id = get_request_value(&request, &["project_id", "projectid"], "project_id")?;
+        let zone = get_request_value(&request, &["zone", "Zone"], "zone")?;
+        let instance = get_request_value(&request, &["instance"], "instance")?;
         let url = format!(
             "{}/projects/{}/zones/{}/instances/{}/reset",
             self.base_url, project_id, zone, instance
@@ -311,8 +344,8 @@ impl GCE {
         &self,
         request: HashMap<String, String>,
     ) -> Result<HashMap<String, String>, Box<dyn std::error::Error>> {
-        let project_id = request.get("projectid").unwrap();
-        let zone = request.get("Zone").unwrap();
+        let project_id = get_request_value(&request, &["project_id", "projectid"], "project_id")?;
+        let zone = get_request_value(&request, &["zone", "Zone"], "zone")?;
         let url = format!(
             "{}/projects/{}/zones/{}/instances/",
             self.base_url, project_id, zone

--- a/rustcloud/src/tests/gcp_compute_operations.rs
+++ b/rustcloud/src/tests/gcp_compute_operations.rs
@@ -12,8 +12,8 @@ async fn test_create_node() {
     let client = create_client().await;
 
     let mut request = HashMap::new();
-    request.insert("projectid".to_string(), json!("your_project_id"));
-    request.insert("Zone".to_string(), json!("your_zone"));
+    request.insert("project_id".to_string(), json!("your_project_id"));
+    request.insert("zone".to_string(), json!("your_zone"));
     request.insert("Name".to_string(), json!("your_instance_name"));
     // Add other required fields for the create_node request here.
 
@@ -26,8 +26,8 @@ async fn test_start_node() {
     let client = create_client().await;
 
     let mut request = HashMap::new();
-    request.insert("projectid".to_string(), "your_project_id".to_string());
-    request.insert("Zone".to_string(), "your_zone".to_string());
+    request.insert("project_id".to_string(), "your_project_id".to_string());
+    request.insert("zone".to_string(), "your_zone".to_string());
     request.insert("instance".to_string(), "your_instance_name".to_string());
 
     let result = client.start_node(request).await;
@@ -39,8 +39,8 @@ async fn test_stop_node() {
     let client = create_client().await;
 
     let mut request = HashMap::new();
-    request.insert("projectid".to_string(), "your_project_id".to_string());
-    request.insert("Zone".to_string(), "your_zone".to_string());
+    request.insert("project_id".to_string(), "your_project_id".to_string());
+    request.insert("zone".to_string(), "your_zone".to_string());
     request.insert("instance".to_string(), "your_instance_name".to_string());
 
     let result = client.stop_node(request).await;
@@ -52,8 +52,8 @@ async fn test_delete_node() {
     let client = create_client().await;
 
     let mut request = HashMap::new();
-    request.insert("projectid".to_string(), "your_project_id".to_string());
-    request.insert("Zone".to_string(), "your_zone".to_string());
+    request.insert("project_id".to_string(), "your_project_id".to_string());
+    request.insert("zone".to_string(), "your_zone".to_string());
     request.insert("instance".to_string(), "your_instance_name".to_string());
 
     let result = client.delete_node(request).await;
@@ -65,8 +65,8 @@ async fn test_reboot_node() {
     let client = create_client().await;
 
     let mut request = HashMap::new();
-    request.insert("projectid".to_string(), "your_project_id".to_string());
-    request.insert("Zone".to_string(), "your_zone".to_string());
+    request.insert("project_id".to_string(), "your_project_id".to_string());
+    request.insert("zone".to_string(), "your_zone".to_string());
     request.insert("instance".to_string(), "your_instance_name".to_string());
 
     let result = client.reboot_node(request).await;
@@ -78,8 +78,8 @@ async fn test_list_node() {
     let client = create_client().await;
 
     let mut request = HashMap::new();
-    request.insert("projectid".to_string(), "your_project_id".to_string());
-    request.insert("Zone".to_string(), "your_zone".to_string());
+    request.insert("project_id".to_string(), "your_project_id".to_string());
+    request.insert("zone".to_string(), "your_zone".to_string());
 
     let result = client.list_node(request).await;
     assert!(result.is_ok());


### PR DESCRIPTION
Normalizes GCE request keys to project_id and zone in docs/tests while keeping backward compatibility with legacy projectid and Zone keys in implementation. Also replaces panic paths for missing required fields with explicit input validation errors.