### PR TITLE
feat: add Azure Key Vault secret operations

### DIFF
--- a/examples/azure/security/key_vault.md
+++ b/examples/azure/security/key_vault.md
@@ -1,0 +1,122 @@
+# rustcloud — Azure Key Vault
+
+Azure Key Vault stores and controls access to secrets, encryption keys, and
+certificates. RustCloud wraps the Key Vault REST API v7.4 for secret operations.
+
+## Configure Credentials
+
+```sh
+export AZURE_KEYVAULT_URL="https://my-vault.vault.azure.net"
+export AZURE_KEYVAULT_TOKEN="<azure-ad-bearer-token>"
+```
+
+To obtain a bearer token with the Azure CLI:
+
+```sh
+az account get-access-token --resource https://vault.azure.net --query accessToken -o tsv
+```
+
+## Initialize the Client
+
+```rust
+use rustcloud::azure::azure_apis::security::azure_key_vault::AzureKeyVault;
+
+// From environment variables
+let vault = AzureKeyVault::new();
+
+// Explicit configuration
+let vault = AzureKeyVault::with_config(
+    "https://my-vault.vault.azure.net",
+    "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9...",
+);
+```
+
+## Operations
+
+### Set a Secret
+
+```rust
+let result = vault.set_secret("db-password", "s3cr3t-v@lue").await?;
+println!("{:?}", result);
+```
+
+### Get a Secret
+
+```rust
+let value = vault.get_secret("db-password").await?;
+println!("Value: {}", value);
+```
+
+### List Secrets
+
+```rust
+let names = vault.list_secrets().await?;
+for name in names {
+    println!("{}", name);
+}
+```
+
+### Get Secret Versions
+
+```rust
+let versions = vault.get_secret_versions("db-password").await?;
+println!("{:?}", versions);
+```
+
+### Delete a Secret
+
+Soft-delete — secret is recoverable within the vault retention period (default 90 days):
+
+```rust
+vault.delete_secret("db-password").await?;
+```
+
+## Full example
+
+```rust
+use rustcloud::azure::azure_apis::security::azure_key_vault::AzureKeyVault;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let vault = AzureKeyVault::new();
+
+    // Store a database connection string
+    vault.set_secret(
+        "prod-db-connection",
+        "Server=tcp:myserver.database.windows.net;Database=mydb;",
+    ).await?;
+
+    // Retrieve it later
+    let conn = vault.get_secret("prod-db-connection").await?;
+    println!("Connecting to: {}", &conn[..30]);
+
+    // Audit: see how many versions exist
+    let versions = vault.get_secret_versions("prod-db-connection").await?;
+    println!("Versions: {:?}", versions["body"]["value"]);
+
+    Ok(())
+}
+```
+
+## Azure security trio
+
+| Service              | Purpose                                       |
+|----------------------|-----------------------------------------------|
+| Azure AD / auth      | Identity and access management                |
+| Azure Key Vault      | Secret, key, and certificate storage          |
+| Azure OpenAI         | AI workloads consuming secrets at runtime     |
+
+## Supported operations
+
+| Function              | Description                                     |
+|-----------------------|-------------------------------------------------|
+| `set_secret`          | Create or update a secret                       |
+| `get_secret`          | Retrieve the latest secret value                |
+| `delete_secret`       | Soft-delete (recoverable)                       |
+| `list_secrets`        | List all secret names in the vault              |
+| `get_secret_versions` | List all versions of a named secret             |
+
+## References
+
+- [Azure Key Vault REST API](https://docs.microsoft.com/en-us/rest/api/keyvault/)
+- [Azure Key Vault Secrets](https://docs.microsoft.com/en-us/azure/key-vault/secrets/)

--- a/rustcloud/src/azure/azure_apis/security/azure_key_vault.rs
+++ b/rustcloud/src/azure/azure_apis/security/azure_key_vault.rs
@@ -1,0 +1,171 @@
+use reqwest::{header::AUTHORIZATION, Client};
+use serde_json::{json, Value};
+use std::env;
+
+const API_VERSION: &str = "7.4";
+
+/// Client for Azure Key Vault secret operations.
+///
+/// Reads credentials from environment variables:
+/// - `AZURE_KEYVAULT_URL`   — vault endpoint, e.g. `https://my-vault.vault.azure.net`
+/// - `AZURE_KEYVAULT_TOKEN` — Azure AD bearer token with `secrets` permissions
+pub struct AzureKeyVault {
+    client: Client,
+    vault_url: String,
+    token: String,
+}
+
+impl AzureKeyVault {
+    pub fn new() -> Self {
+        Self {
+            client: Client::new(),
+            vault_url: env::var("AZURE_KEYVAULT_URL")
+                .expect("AZURE_KEYVAULT_URL must be set"),
+            token: env::var("AZURE_KEYVAULT_TOKEN")
+                .expect("AZURE_KEYVAULT_TOKEN must be set"),
+        }
+    }
+
+    pub fn with_config(vault_url: &str, token: &str) -> Self {
+        Self {
+            client: Client::new(),
+            vault_url: vault_url.to_string(),
+            token: token.to_string(),
+        }
+    }
+
+    fn auth_header(&self) -> String {
+        format!("Bearer {}", self.token)
+    }
+
+    /// Create or update a secret. Returns the full secret object from the vault.
+    pub async fn set_secret(
+        &self,
+        name: &str,
+        value: &str,
+    ) -> Result<Value, Box<dyn std::error::Error>> {
+        let url = format!(
+            "{}/secrets/{}?api-version={}",
+            self.vault_url, name, API_VERSION
+        );
+        let body = json!({ "value": value });
+
+        let resp = self
+            .client
+            .put(&url)
+            .header(AUTHORIZATION, self.auth_header())
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send()
+            .await?;
+
+        let status = resp.status().as_u16();
+        let body: Value = resp.json().await?;
+        println!("Set secret '{}': status {}", name, status);
+        Ok(json!({ "status": status, "body": body }))
+    }
+
+    /// Retrieve the latest version of a secret's value.
+    pub async fn get_secret(
+        &self,
+        name: &str,
+    ) -> Result<String, Box<dyn std::error::Error>> {
+        let url = format!(
+            "{}/secrets/{}?api-version={}",
+            self.vault_url, name, API_VERSION
+        );
+
+        let resp = self
+            .client
+            .get(&url)
+            .header(AUTHORIZATION, self.auth_header())
+            .send()
+            .await?;
+
+        let body: Value = resp.json().await?;
+        let value = body["value"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string();
+        println!("Retrieved secret '{}'", name);
+        Ok(value)
+    }
+
+    /// Soft-delete a secret (recoverable within the vault's retention period).
+    pub async fn delete_secret(
+        &self,
+        name: &str,
+    ) -> Result<Value, Box<dyn std::error::Error>> {
+        let url = format!(
+            "{}/secrets/{}?api-version={}",
+            self.vault_url, name, API_VERSION
+        );
+
+        let resp = self
+            .client
+            .delete(&url)
+            .header(AUTHORIZATION, self.auth_header())
+            .send()
+            .await?;
+
+        let status = resp.status().as_u16();
+        let body: Value = resp.json().await?;
+        println!("Deleted secret '{}': status {}", name, status);
+        Ok(json!({ "status": status, "body": body }))
+    }
+
+    /// List all secret names in the vault (not their values).
+    pub async fn list_secrets(&self) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+        let url = format!(
+            "{}/secrets?api-version={}",
+            self.vault_url, API_VERSION
+        );
+
+        let resp = self
+            .client
+            .get(&url)
+            .header(AUTHORIZATION, self.auth_header())
+            .send()
+            .await?;
+
+        let body: Value = resp.json().await?;
+        let names: Vec<String> = body["value"]
+            .as_array()
+            .unwrap_or(&vec![])
+            .iter()
+            .filter_map(|item| {
+                item["id"].as_str().and_then(|id| {
+                    id.split('/').rev().nth(1).map(|n| n.to_string())
+                })
+            })
+            .collect();
+
+        for name in &names {
+            println!("Secret: {}", name);
+        }
+        Ok(names)
+    }
+
+    /// List all versions of a secret by name.
+    pub async fn get_secret_versions(
+        &self,
+        name: &str,
+    ) -> Result<Value, Box<dyn std::error::Error>> {
+        let url = format!(
+            "{}/secrets/{}/versions?api-version={}",
+            self.vault_url, name, API_VERSION
+        );
+
+        let resp = self
+            .client
+            .get(&url)
+            .header(AUTHORIZATION, self.auth_header())
+            .send()
+            .await?;
+
+        let status = resp.status().as_u16();
+        let body: Value = resp.json().await?;
+        println!("Versions for '{}': status {}", name, status);
+        Ok(json!({ "status": status, "body": body }))
+    }
+}

--- a/rustcloud/src/tests/azure_key_vault_operations.rs
+++ b/rustcloud/src/tests/azure_key_vault_operations.rs
@@ -1,0 +1,49 @@
+use crate::azure::azure_apis::security::azure_key_vault::AzureKeyVault;
+
+fn get_client() -> AzureKeyVault {
+    AzureKeyVault::new()
+}
+
+#[tokio::test]
+async fn test_set_secret() {
+    let client = get_client();
+    let result = client.set_secret("rustcloud-test-secret", "hello-rustcloud").await;
+    assert!(result.is_ok());
+    let resp = result.unwrap();
+    println!("Set secret: {:?}", resp);
+}
+
+#[tokio::test]
+async fn test_get_secret() {
+    let client = get_client();
+    let result = client.get_secret("rustcloud-test-secret").await;
+    assert!(result.is_ok());
+    let value = result.unwrap();
+    assert_eq!(value, "hello-rustcloud");
+    println!("Got secret value: {}", value);
+}
+
+#[tokio::test]
+async fn test_list_secrets() {
+    let client = get_client();
+    let result = client.list_secrets().await;
+    assert!(result.is_ok());
+    let names = result.unwrap();
+    println!("Secrets in vault: {:?}", names);
+}
+
+#[tokio::test]
+async fn test_get_secret_versions() {
+    let client = get_client();
+    let result = client.get_secret_versions("rustcloud-test-secret").await;
+    assert!(result.is_ok());
+    println!("Versions: {:?}", result.unwrap());
+}
+
+#[tokio::test]
+async fn test_delete_secret() {
+    let client = get_client();
+    let result = client.delete_secret("rustcloud-test-secret").await;
+    assert!(result.is_ok());
+    println!("Deleted: {:?}", result.unwrap());
+}


### PR DESCRIPTION
Closes #92 

Implements Azure Key Vault REST API v7.4 for secret management:
`set_secret`, `get_secret`, `delete_secret`, `list_secrets`, `get_secret_versions`.

- `AzureKeyVault` struct reading `AZURE_KEYVAULT_URL` + `AZURE_KEYVAULT_TOKEN`
- Adds `pub mod security` to the Azure module tree (first Azure security service)
- Soft-delete support with vault retention period
- 5 integration tests + usage guide at `examples/azure/security/key_vault.md`
- AWS equivalent: Secrets Manager (#XX)