### PR TITLE
feat: add GCP Cloud Storage (GCS) bucket and object operations

### DIFF
--- a/examples/gcp/storage/cloud_storage.md
+++ b/examples/gcp/storage/cloud_storage.md
@@ -1,0 +1,141 @@
+# rustcloud — GCP Cloud Storage (GCS)
+
+Google Cloud Storage is GCP's object storage service for blobs, files, and
+static assets. RustCloud wraps the GCS JSON API v1 for bucket and object operations.
+
+> **Note:** The existing `gcp_storage.rs` file implements Compute Engine
+> persistent disk operations. This module (`gcp_object_storage`) covers GCS
+> bucket and object management.
+
+## Configure Credentials
+
+```sh
+export GOOGLE_APPLICATION_CREDENTIALS="/path/to/service-account.json"
+export GCP_PROJECT_ID="my-project"
+# or: gcloud auth application-default login
+```
+
+## Initialize the Client
+
+```rust
+use rustcloud::gcp::gcp_apis::storage::gcp_object_storage::GcsClient;
+
+let client = GcsClient::new("my-gcp-project");
+```
+
+## Operations
+
+### Create a Bucket
+
+```rust
+let result = client.create_bucket("my-app-assets", "US-EAST1").await?;
+println!("Status: {}", result["status"]);
+```
+
+Common locations: `US`, `EU`, `ASIA`, `US-EAST1`, `US-CENTRAL1`, `EUROPE-WEST1`
+
+### List Buckets
+
+```rust
+let result = client.list_buckets().await?;
+if let Some(items) = result["body"]["items"].as_array() {
+    for bucket in items {
+        println!("{}", bucket["name"]);
+    }
+}
+```
+
+### Upload an Object
+
+```rust
+let content = std::fs::read("logo.png")?;
+let result = client
+    .upload_object("my-app-assets", "images/logo.png", "image/png", content)
+    .await?;
+println!("Uploaded: {:?}", result["body"]["selfLink"]);
+```
+
+### Download an Object
+
+```rust
+let bytes = client.download_object("my-app-assets", "images/logo.png").await?;
+std::fs::write("logo-downloaded.png", bytes)?;
+```
+
+### List Objects
+
+```rust
+// All objects
+let result = client.list_objects("my-app-assets", None).await?;
+
+// With prefix filter
+let result = client.list_objects("my-app-assets", Some("images/")).await?;
+if let Some(items) = result["body"]["items"].as_array() {
+    for obj in items {
+        println!("{} — {} bytes", obj["name"], obj["size"]);
+    }
+}
+```
+
+### Delete an Object
+
+```rust
+client.delete_object("my-app-assets", "images/logo.png").await?;
+```
+
+### Delete a Bucket
+
+Bucket must be empty before deletion:
+
+```rust
+client.delete_bucket("my-app-assets").await?;
+```
+
+## Full example — upload and serve static assets
+
+```rust
+use rustcloud::gcp::gcp_apis::storage::gcp_object_storage::GcsClient;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = GcsClient::new("my-project");
+    let bucket = "my-static-assets";
+
+    client.create_bucket(bucket, "US").await?;
+
+    for file in ["index.html", "style.css", "app.js"] {
+        let bytes = std::fs::read(format!("dist/{}", file))?;
+        let mime = match file.rsplit('.').next() {
+            Some("html") => "text/html",
+            Some("css")  => "text/css",
+            Some("js")   => "application/javascript",
+            _            => "application/octet-stream",
+        };
+        client.upload_object(bucket, file, mime, bytes).await?;
+        println!("Uploaded {}", file);
+    }
+
+    let objects = client.list_objects(bucket, None).await?;
+    println!("Objects in bucket: {:?}", objects["body"]["items"]);
+
+    Ok(())
+}
+```
+
+## Supported operations
+
+| Function          | Description                                     |
+|-------------------|-------------------------------------------------|
+| `create_bucket`   | Create a bucket in a given location             |
+| `delete_bucket`   | Delete an empty bucket                          |
+| `list_buckets`    | List all buckets in the project                 |
+| `upload_object`   | Upload bytes with content type                  |
+| `download_object` | Download object content as raw bytes            |
+| `delete_object`   | Delete a named object                           |
+| `list_objects`    | List objects with optional prefix filter        |
+
+## References
+
+- [GCS JSON API](https://cloud.google.com/storage/docs/json_api/v1)
+- [GCS Buckets](https://cloud.google.com/storage/docs/creating-buckets)
+- [GCS Objects](https://cloud.google.com/storage/docs/uploading-objects)

--- a/rustcloud/src/gcp/gcp_apis/storage/gcp_object_storage.rs
+++ b/rustcloud/src/gcp/gcp_apis/storage/gcp_object_storage.rs
@@ -1,0 +1,201 @@
+use crate::gcp::gcp_apis::auth::gcp_auth::retrieve_token;
+use reqwest::{header::AUTHORIZATION, Client};
+use serde_json::{json, Value};
+
+const GCS_BASE: &str = "https://storage.googleapis.com/storage/v1";
+const GCS_UPLOAD: &str = "https://storage.googleapis.com/upload/storage/v1";
+
+/// Client for Google Cloud Storage bucket and object operations.
+pub struct GcsClient {
+    client: Client,
+    project_id: String,
+}
+
+impl GcsClient {
+    pub fn new(project_id: &str) -> Self {
+        Self {
+            client: Client::new(),
+            project_id: project_id.to_string(),
+        }
+    }
+
+    // ── Bucket operations ─────────────────────────────────────────────────────
+
+    /// Create a new bucket in the given location (e.g. `"US-EAST1"`, `"EU"`).
+    pub async fn create_bucket(
+        &self,
+        bucket_name: &str,
+        location: &str,
+    ) -> Result<Value, Box<dyn std::error::Error>> {
+        let url = format!("{}/b?project={}", GCS_BASE, self.project_id);
+        let token = retrieve_token().await?;
+        let body = json!({
+            "name": bucket_name,
+            "location": location,
+        });
+
+        let resp = self
+            .client
+            .post(&url)
+            .header(AUTHORIZATION, format!("Bearer {}", token))
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send()
+            .await?;
+
+        let status = resp.status().as_u16();
+        let body: Value = resp.json().await?;
+        println!("create_bucket '{}': status {}", bucket_name, status);
+        Ok(json!({ "status": status, "body": body }))
+    }
+
+    /// Delete a bucket. The bucket must be empty before deletion.
+    pub async fn delete_bucket(
+        &self,
+        bucket_name: &str,
+    ) -> Result<Value, Box<dyn std::error::Error>> {
+        let url = format!("{}/b/{}", GCS_BASE, bucket_name);
+        let token = retrieve_token().await?;
+
+        let resp = self
+            .client
+            .delete(&url)
+            .header(AUTHORIZATION, format!("Bearer {}", token))
+            .send()
+            .await?;
+
+        let status = resp.status().as_u16();
+        let body = resp.text().await.unwrap_or_default();
+        println!("delete_bucket '{}': status {}", bucket_name, status);
+        Ok(json!({ "status": status, "body": body }))
+    }
+
+    /// List all buckets in the project.
+    pub async fn list_buckets(&self) -> Result<Value, Box<dyn std::error::Error>> {
+        let url = format!("{}/b?project={}", GCS_BASE, self.project_id);
+        let token = retrieve_token().await?;
+
+        let resp = self
+            .client
+            .get(&url)
+            .header(AUTHORIZATION, format!("Bearer {}", token))
+            .send()
+            .await?;
+
+        let status = resp.status().as_u16();
+        let body: Value = resp.json().await?;
+        println!("list_buckets: status {}", status);
+        Ok(json!({ "status": status, "body": body }))
+    }
+
+    // ── Object operations ─────────────────────────────────────────────────────
+
+    /// Upload bytes to `bucket/object_name` with the given content type.
+    /// Uses the GCS simple media upload endpoint.
+    pub async fn upload_object(
+        &self,
+        bucket_name: &str,
+        object_name: &str,
+        content_type: &str,
+        data: Vec<u8>,
+    ) -> Result<Value, Box<dyn std::error::Error>> {
+        let url = format!(
+            "{}/b/{}/o?uploadType=media&name={}",
+            GCS_UPLOAD, bucket_name, object_name
+        );
+        let token = retrieve_token().await?;
+
+        let resp = self
+            .client
+            .post(&url)
+            .header(AUTHORIZATION, format!("Bearer {}", token))
+            .header("Content-Type", content_type)
+            .body(data)
+            .send()
+            .await?;
+
+        let status = resp.status().as_u16();
+        let body: Value = resp.json().await?;
+        println!("upload_object '{}/{}': status {}", bucket_name, object_name, status);
+        Ok(json!({ "status": status, "body": body }))
+    }
+
+    /// Download an object and return its raw bytes.
+    pub async fn download_object(
+        &self,
+        bucket_name: &str,
+        object_name: &str,
+    ) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+        // URL-encode the object name to handle slashes and special characters
+        let encoded_name = object_name.replace('/', "%2F");
+        let url = format!(
+            "{}/b/{}/o/{}?alt=media",
+            GCS_BASE, bucket_name, encoded_name
+        );
+        let token = retrieve_token().await?;
+
+        let resp = self
+            .client
+            .get(&url)
+            .header(AUTHORIZATION, format!("Bearer {}", token))
+            .send()
+            .await?;
+
+        println!(
+            "download_object '{}/{}': status {}",
+            bucket_name,
+            object_name,
+            resp.status().as_u16()
+        );
+        let bytes = resp.bytes().await?;
+        Ok(bytes.to_vec())
+    }
+
+    /// Delete a single object from a bucket.
+    pub async fn delete_object(
+        &self,
+        bucket_name: &str,
+        object_name: &str,
+    ) -> Result<Value, Box<dyn std::error::Error>> {
+        let encoded_name = object_name.replace('/', "%2F");
+        let url = format!("{}/b/{}/o/{}", GCS_BASE, bucket_name, encoded_name);
+        let token = retrieve_token().await?;
+
+        let resp = self
+            .client
+            .delete(&url)
+            .header(AUTHORIZATION, format!("Bearer {}", token))
+            .send()
+            .await?;
+
+        let status = resp.status().as_u16();
+        let body = resp.text().await.unwrap_or_default();
+        println!("delete_object '{}/{}': status {}", bucket_name, object_name, status);
+        Ok(json!({ "status": status, "body": body }))
+    }
+
+    /// List objects in a bucket, optionally filtered by name prefix.
+    pub async fn list_objects(
+        &self,
+        bucket_name: &str,
+        prefix: Option<&str>,
+    ) -> Result<Value, Box<dyn std::error::Error>> {
+        let mut url = format!("{}/b/{}/o", GCS_BASE, bucket_name);
+        if let Some(p) = prefix {
+            url = format!("{}?prefix={}", url, p);
+        }
+        let token = retrieve_token().await?;
+
+        let resp = self
+            .client
+            .get(&url)
+            .header(AUTHORIZATION, format!("Bearer {}", token))
+            .send()
+            .await?;
+
+        let status = resp.status().as_u16();
+        let body: Value = resp.json().await?;
+        println!("list_objects '{}': status {}", bucket_name, status);
+        Ok(json!({ "status": status, "body": body }))
+    }
+}

--- a/rustcloud/src/tests/gcp_object_storage_operations.rs
+++ b/rustcloud/src/tests/gcp_object_storage_operations.rs
@@ -1,0 +1,67 @@
+use crate::gcp::gcp_apis::storage::gcp_object_storage::GcsClient;
+
+fn get_client() -> GcsClient {
+    let project_id = std::env::var("GCP_PROJECT_ID").unwrap_or("your-project-id".to_string());
+    GcsClient::new(&project_id)
+}
+
+#[tokio::test]
+async fn test_create_bucket() {
+    let client = get_client();
+    let result = client
+        .create_bucket("rustcloud-test-bucket-01", "US-EAST1")
+        .await;
+    assert!(result.is_ok());
+    let resp = result.unwrap();
+    println!("Created bucket: {:?}", resp["status"]);
+}
+
+#[tokio::test]
+async fn test_list_buckets() {
+    let client = get_client();
+    let result = client.list_buckets().await;
+    assert!(result.is_ok());
+    println!("Buckets: {:?}", result.unwrap()["body"]["items"]);
+}
+
+#[tokio::test]
+async fn test_upload_and_download_object() {
+    let client = get_client();
+    let bucket = "rustcloud-test-bucket-01";
+    let content = b"hello from rustcloud".to_vec();
+
+    let upload = client
+        .upload_object(bucket, "test/hello.txt", "text/plain", content.clone())
+        .await;
+    assert!(upload.is_ok());
+    println!("Uploaded: {:?}", upload.unwrap()["status"]);
+
+    let downloaded = client.download_object(bucket, "test/hello.txt").await;
+    assert!(downloaded.is_ok());
+    let bytes = downloaded.unwrap();
+    assert_eq!(bytes, content);
+    println!("Downloaded {} bytes", bytes.len());
+}
+
+#[tokio::test]
+async fn test_list_objects() {
+    let client = get_client();
+    let result = client
+        .list_objects("rustcloud-test-bucket-01", Some("test/"))
+        .await;
+    assert!(result.is_ok());
+    println!("Objects: {:?}", result.unwrap()["body"]["items"]);
+}
+
+#[tokio::test]
+async fn test_delete_object_and_bucket() {
+    let client = get_client();
+    let bucket = "rustcloud-test-bucket-01";
+
+    let obj_result = client.delete_object(bucket, "test/hello.txt").await;
+    assert!(obj_result.is_ok());
+
+    let bucket_result = client.delete_bucket(bucket).await;
+    assert!(bucket_result.is_ok());
+    println!("Cleanup complete");
+}


### PR DESCRIPTION
Closes #94 

Adds `GcsClient` with 7 GCS JSON API operations: `create_bucket`, `delete_bucket`,
`list_buckets`, `upload_object`, `download_object`, `delete_object`, `list_objects`.

**Note:** The existing `gcp_storage.rs` implements Compute Engine *persistent disk*
operations (create_disk, delete_disk, create_snapshot) — not Cloud Storage. This PR
adds the missing GCS object storage layer as a separate `gcp_object_storage.rs`.

- Follows the existing GCP struct pattern (`retrieve_token()` + reqwest)
- Supports prefix-filtered object listing
- URL-encodes object names to handle path separators correctly
- 5 integration tests covering full bucket + object lifecycle
- Usage guide at `examples/gcp/storage/cloud_storage.md`