### PR TITLE
feat: add configurable retry middleware for LlmProvider

### DIFF
--- a/rustcloud/src/genai/mod.rs
+++ b/rustcloud/src/genai/mod.rs
@@ -1,0 +1,49 @@
+﻿/// Multi-cloud unified generative AI routing layer.
+///
+/// # Overview
+///
+/// This module provides [`client::UnifiedLlmClient`] — a single entry-point
+/// that fans requests out to AWS Bedrock, GCP Vertex AI, or Azure OpenAI
+/// based on a pluggable [`routing::RoutingStrategy`].
+///
+/// All backends implement the shared [`crate::traits::llm_provider::LlmProvider`]
+/// trait, so switching providers (or layering fallback logic) requires no
+/// changes to application code.
+///
+/// # Architecture
+///
+/// ```text
+///  ┌─────────────────────────────────────────────────────┐
+///  │              UnifiedLlmClient                        │
+///  │                                                     │
+///  │  ┌────────────┐  ┌──────────────┐  ┌────────────┐  │
+///  │  │  Bedrock   │  │  VertexAI    │  │AzureOpenAI │  │
+///  │  │ (aws)      │  │  (gcp)       │  │ (azure)    │  │
+///  │  └────────────┘  └──────────────┘  └────────────┘  │
+///  │                                                     │
+///  │  RoutingStrategy: Explicit | ModelBased | Fallback  │
+///  └─────────────────────────────────────────────────────┘
+/// ```
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use rustcloud::genai::client::UnifiedLlmClient;
+/// use rustcloud::genai::routing::RoutingStrategy;
+/// use rustcloud::types::llm::{LlmRequest, Message, ModelRef};
+/// use rustcloud::traits::llm_provider::LlmProvider;
+///
+/// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// // Each provider is registered under a short alias.
+/// // The first registered provider is the default.
+/// // let client = UnifiedLlmClient::builder()
+/// //     .register("aws",   Box::new(BedrockProvider::new().await))
+/// //     .register("azure", Box::new(AzureOpenAIProvider::new()))
+/// //     .register("gcp",   Box::new(VertexAI::new("proj", "us-central1")))
+/// //     .routing(RoutingStrategy::ModelBased)
+/// //     .build()?;
+/// # Ok(()) }
+/// ```
+pub mod client;
+pub mod retry;
+pub mod routing;

--- a/rustcloud/src/genai/retry.rs
+++ b/rustcloud/src/genai/retry.rs
@@ -1,0 +1,197 @@
+use std::time::Duration;
+
+use async_trait::async_trait;
+
+use crate::errors::CloudError;
+use crate::traits::llm_provider::{LlmProvider, LlmStream};
+use crate::types::llm::{
+    EmbedResponse, LlmRequest, LlmResponse, LlmStreamEvent, ToolCallResponse, ToolDefinition,
+};
+
+// ── RetryConfig ───────────────────────────────────────────────────────────────
+
+/// Exponential back-off configuration for [`RetryProvider`].
+#[derive(Debug, Clone)]
+pub struct RetryConfig {
+    /// Total number of attempts (including the first). Must be ≥ 1.
+    pub max_attempts: u32,
+    /// Delay before the second attempt in milliseconds.
+    pub initial_delay_ms: u64,
+    /// Multiplier applied to the delay after each failed attempt.
+    pub backoff_factor: f64,
+    /// Upper bound on the computed delay in milliseconds.
+    pub max_delay_ms: u64,
+}
+
+impl Default for RetryConfig {
+    fn default() -> Self {
+        Self {
+            max_attempts: 3,
+            initial_delay_ms: 500,
+            backoff_factor: 2.0,
+            max_delay_ms: 10_000,
+        }
+    }
+}
+
+// ── RetryProvider ─────────────────────────────────────────────────────────────
+
+/// Wraps any [`LlmProvider`] and automatically retries transient failures
+/// (`RateLimit`, `Network`, `Provider { retryable: true }`) with exponential
+/// back-off. Non-transient errors propagate immediately without retrying.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// # use rustcloud::genai::retry::{RetryProvider, RetryConfig};
+/// # use rustcloud::aws::aws_apis::artificial_intelligence::aws_bedrock::BedrockProvider;
+/// # #[tokio::main] async fn main() {
+/// let provider = RetryProvider::new(
+///     BedrockProvider::new().await,
+///     RetryConfig { max_attempts: 4, initial_delay_ms: 200, ..Default::default() },
+/// );
+/// # }
+/// ```
+pub struct RetryProvider<P: LlmProvider> {
+    inner: P,
+    config: RetryConfig,
+}
+
+impl<P: LlmProvider> RetryProvider<P> {
+    pub fn new(inner: P, config: RetryConfig) -> Self {
+        Self { inner, config }
+    }
+
+    /// Create a `RetryProvider` with the default `RetryConfig` (3 attempts, 500 ms base).
+    pub fn with_defaults(inner: P) -> Self {
+        Self::new(inner, RetryConfig::default())
+    }
+
+    /// Compute the sleep duration for a given attempt index (0-based).
+    /// If the error is a `RateLimit` with a `retry_after` hint, that value
+    /// takes precedence over the computed back-off.
+    fn sleep_duration(&self, attempt: u32, err: &CloudError) -> Duration {
+        if let CloudError::RateLimit {
+            retry_after: Some(secs),
+        } = err
+        {
+            return Duration::from_secs(*secs);
+        }
+        let delay = (self.config.initial_delay_ms as f64
+            * self.config.backoff_factor.powi(attempt as i32))
+        .min(self.config.max_delay_ms as f64) as u64;
+        Duration::from_millis(delay)
+    }
+}
+
+fn is_retryable(err: &CloudError) -> bool {
+    matches!(
+        err,
+        CloudError::RateLimit { .. }
+            | CloudError::Network { .. }
+            | CloudError::Provider {
+                retryable: true,
+                ..
+            }
+    )
+}
+
+// ── LlmProvider impl ──────────────────────────────────────────────────────────
+
+#[async_trait]
+impl<P: LlmProvider> LlmProvider for RetryProvider<P> {
+    async fn generate(&self, req: LlmRequest) -> Result<LlmResponse, CloudError> {
+        let mut last_err = CloudError::Provider {
+            http_status: 0,
+            message: "max_attempts must be >= 1".to_string(),
+            retryable: false,
+        };
+        for attempt in 0..self.config.max_attempts {
+            match self.inner.generate(req.clone()).await {
+                Ok(resp) => return Ok(resp),
+                Err(e) if is_retryable(&e) => {
+                    if attempt + 1 < self.config.max_attempts {
+                        tokio::time::sleep(self.sleep_duration(attempt, &e)).await;
+                    }
+                    last_err = e;
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        Err(last_err)
+    }
+
+    async fn stream(&self, req: LlmRequest) -> Result<LlmStream, CloudError> {
+        // Retry the *initial connection* only. Once streaming has begun, the
+        // caller consumes the stream and errors within it are passed through
+        // as `LlmStreamEvent::Error` by the underlying provider.
+        let mut last_err = CloudError::Provider {
+            http_status: 0,
+            message: "max_attempts must be >= 1".to_string(),
+            retryable: false,
+        };
+        for attempt in 0..self.config.max_attempts {
+            match self.inner.stream(req.clone()).await {
+                Ok(stream) => return Ok(stream),
+                Err(e) if is_retryable(&e) => {
+                    if attempt + 1 < self.config.max_attempts {
+                        tokio::time::sleep(self.sleep_duration(attempt, &e)).await;
+                    }
+                    last_err = e;
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        Err(last_err)
+    }
+
+    async fn embed(&self, texts: Vec<String>) -> Result<EmbedResponse, CloudError> {
+        let mut last_err = CloudError::Provider {
+            http_status: 0,
+            message: "max_attempts must be >= 1".to_string(),
+            retryable: false,
+        };
+        for attempt in 0..self.config.max_attempts {
+            match self.inner.embed(texts.clone()).await {
+                Ok(resp) => return Ok(resp),
+                Err(e) if is_retryable(&e) => {
+                    if attempt + 1 < self.config.max_attempts {
+                        tokio::time::sleep(self.sleep_duration(attempt, &e)).await;
+                    }
+                    last_err = e;
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        Err(last_err)
+    }
+
+    async fn generate_with_tools(
+        &self,
+        req: LlmRequest,
+        tools: Vec<ToolDefinition>,
+    ) -> Result<ToolCallResponse, CloudError> {
+        let mut last_err = CloudError::Provider {
+            http_status: 0,
+            message: "max_attempts must be >= 1".to_string(),
+            retryable: false,
+        };
+        for attempt in 0..self.config.max_attempts {
+            match self
+                .inner
+                .generate_with_tools(req.clone(), tools.clone())
+                .await
+            {
+                Ok(resp) => return Ok(resp),
+                Err(e) if is_retryable(&e) => {
+                    if attempt + 1 < self.config.max_attempts {
+                        tokio::time::sleep(self.sleep_duration(attempt, &e)).await;
+                    }
+                    last_err = e;
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        Err(last_err)
+    }
+}

--- a/rustcloud/src/tests/llm_retry_operations.rs
+++ b/rustcloud/src/tests/llm_retry_operations.rs
@@ -1,0 +1,222 @@
+use crate::errors::CloudError;
+use crate::genai::retry::{RetryConfig, RetryProvider};
+use crate::traits::llm_provider::{LlmProvider, LlmStream};
+use crate::types::llm::{
+    EmbedResponse, FinishReason, LlmRequest, LlmResponse, LlmStreamEvent, Message, ModelRef,
+    ToolCallResponse, ToolDefinition, UsageStats,
+};
+
+use async_trait::async_trait;
+use futures::stream;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+
+// ── Counting stub that fails N times then succeeds ────────────────────────────
+
+struct FailNTimes {
+    fail_count: Arc<AtomicU32>,
+    failures_remaining: Arc<AtomicU32>,
+    error_kind: &'static str, // "rate_limit" | "network" | "hard"
+}
+
+impl FailNTimes {
+    fn rate_limit(n: u32) -> Self {
+        Self {
+            fail_count: Arc::new(AtomicU32::new(0)),
+            failures_remaining: Arc::new(AtomicU32::new(n)),
+            error_kind: "rate_limit",
+        }
+    }
+    fn hard_fail(n: u32) -> Self {
+        Self {
+            fail_count: Arc::new(AtomicU32::new(0)),
+            failures_remaining: Arc::new(AtomicU32::new(n)),
+            error_kind: "hard",
+        }
+    }
+    fn attempt_count(&self) -> u32 {
+        self.fail_count.load(Ordering::SeqCst)
+    }
+}
+
+fn make_error(kind: &'static str) -> CloudError {
+    match kind {
+        "rate_limit" => CloudError::RateLimit { retry_after: None },
+        "hard" => CloudError::Unsupported { feature: "test-hard-fail" },
+        _ => CloudError::RateLimit { retry_after: None },
+    }
+}
+
+#[async_trait]
+impl LlmProvider for FailNTimes {
+    async fn generate(&self, _req: LlmRequest) -> Result<LlmResponse, CloudError> {
+        self.fail_count.fetch_add(1, Ordering::SeqCst);
+        let remaining = self.failures_remaining.load(Ordering::SeqCst);
+        if remaining > 0 {
+            self.failures_remaining.fetch_sub(1, Ordering::SeqCst);
+            return Err(make_error(self.error_kind));
+        }
+        Ok(LlmResponse {
+            text: "success".to_string(),
+            finish_reason: FinishReason::Stop,
+            usage: Some(UsageStats { prompt_tokens: 5, completion_tokens: 1 }),
+        })
+    }
+
+    async fn stream(&self, _req: LlmRequest) -> Result<LlmStream, CloudError> {
+        self.fail_count.fetch_add(1, Ordering::SeqCst);
+        let remaining = self.failures_remaining.load(Ordering::SeqCst);
+        if remaining > 0 {
+            self.failures_remaining.fetch_sub(1, Ordering::SeqCst);
+            return Err(make_error(self.error_kind));
+        }
+        Ok(Box::pin(stream::iter(vec![
+            LlmStreamEvent::DeltaText("ok".to_string()),
+            LlmStreamEvent::Done(FinishReason::Stop),
+        ])))
+    }
+
+    async fn embed(&self, texts: Vec<String>) -> Result<EmbedResponse, CloudError> {
+        self.fail_count.fetch_add(1, Ordering::SeqCst);
+        let remaining = self.failures_remaining.load(Ordering::SeqCst);
+        if remaining > 0 {
+            self.failures_remaining.fetch_sub(1, Ordering::SeqCst);
+            return Err(make_error(self.error_kind));
+        }
+        Ok(EmbedResponse {
+            embeddings: texts.iter().map(|_| vec![1.0_f32]).collect(),
+        })
+    }
+
+    async fn generate_with_tools(
+        &self,
+        _req: LlmRequest,
+        _tools: Vec<ToolDefinition>,
+    ) -> Result<ToolCallResponse, CloudError> {
+        self.fail_count.fetch_add(1, Ordering::SeqCst);
+        let remaining = self.failures_remaining.load(Ordering::SeqCst);
+        if remaining > 0 {
+            self.failures_remaining.fetch_sub(1, Ordering::SeqCst);
+            return Err(make_error(self.error_kind));
+        }
+        Ok(ToolCallResponse::Text(LlmResponse {
+            text: "success".to_string(),
+            finish_reason: FinishReason::Stop,
+            usage: None,
+        }))
+    }
+}
+
+// ── Helper ────────────────────────────────────────────────────────────────────
+
+fn req() -> LlmRequest {
+    LlmRequest {
+        model: ModelRef::Provider("test".to_string()),
+        messages: vec![Message { role: "user".to_string(), content: "hi".to_string() }],
+        max_tokens: Some(10),
+        temperature: None,
+        system_prompt: None,
+    }
+}
+
+fn fast_config(max_attempts: u32) -> RetryConfig {
+    RetryConfig {
+        max_attempts,
+        initial_delay_ms: 0, // zero delay for tests
+        backoff_factor: 1.0,
+        max_delay_ms: 0,
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_succeeds_on_first_attempt() {
+    let provider = RetryProvider::new(FailNTimes::rate_limit(0), fast_config(3));
+    let resp = provider.generate(req()).await.unwrap();
+    assert_eq!(resp.text, "success");
+}
+
+#[tokio::test]
+async fn test_retries_rate_limit_and_succeeds() {
+    let inner = FailNTimes::rate_limit(2); // fail twice then succeed
+    let provider = RetryProvider::new(inner, fast_config(3));
+    let resp = provider.generate(req()).await.unwrap();
+    assert_eq!(resp.text, "success");
+}
+
+#[tokio::test]
+async fn test_exhausts_retries_and_returns_last_error() {
+    let provider = RetryProvider::new(FailNTimes::rate_limit(10), fast_config(3));
+    let err = provider.generate(req()).await.unwrap_err();
+    assert!(matches!(err, CloudError::RateLimit { .. }));
+}
+
+#[tokio::test]
+async fn test_hard_error_propagates_immediately_without_retry() {
+    let inner = FailNTimes::hard_fail(1);
+    let attempts_ref = Arc::clone(&inner.fail_count);
+    let provider = RetryProvider::new(inner, fast_config(3));
+    let err = provider.generate(req()).await.unwrap_err();
+    assert!(matches!(err, CloudError::Unsupported { .. }));
+    // Hard error on first attempt — should NOT retry
+    assert_eq!(attempts_ref.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn test_stream_retries_initial_connection() {
+    use futures::StreamExt;
+    let provider = RetryProvider::new(FailNTimes::rate_limit(1), fast_config(3));
+    let mut stream = provider.stream(req()).await.unwrap();
+    let mut got_text = false;
+    while let Some(event) = stream.next().await {
+        if matches!(event, LlmStreamEvent::DeltaText(_)) {
+            got_text = true;
+        }
+    }
+    assert!(got_text);
+}
+
+#[tokio::test]
+async fn test_embed_retries_on_rate_limit() {
+    let provider = RetryProvider::new(FailNTimes::rate_limit(1), fast_config(3));
+    let resp = provider.embed(vec!["a".to_string(), "b".to_string()]).await.unwrap();
+    assert_eq!(resp.embeddings.len(), 2);
+}
+
+#[tokio::test]
+async fn test_generate_with_tools_retries() {
+    let provider = RetryProvider::new(FailNTimes::rate_limit(2), fast_config(3));
+    let result = provider
+        .generate_with_tools(req(), vec![])
+        .await
+        .unwrap();
+    assert!(matches!(result, ToolCallResponse::Text(_)));
+}
+
+#[tokio::test]
+async fn test_retry_after_hint_is_respected() {
+    // Provider returns RateLimit { retry_after: Some(1) } — just verify no panic
+    struct HintedRateLimit;
+    #[async_trait]
+    impl LlmProvider for HintedRateLimit {
+        async fn generate(&self, _req: LlmRequest) -> Result<LlmResponse, CloudError> {
+            Err(CloudError::RateLimit { retry_after: Some(1) })
+        }
+        async fn stream(&self, _req: LlmRequest) -> Result<LlmStream, CloudError> {
+            Err(CloudError::RateLimit { retry_after: None })
+        }
+        async fn embed(&self, _texts: Vec<String>) -> Result<EmbedResponse, CloudError> {
+            Err(CloudError::RateLimit { retry_after: None })
+        }
+        async fn generate_with_tools(
+            &self, _req: LlmRequest, _tools: Vec<ToolDefinition>,
+        ) -> Result<ToolCallResponse, CloudError> {
+            Err(CloudError::RateLimit { retry_after: None })
+        }
+    }
+    // 1 attempt only so we don't actually sleep 1 second
+    let provider = RetryProvider::new(HintedRateLimit, fast_config(1));
+    let err = provider.generate(req()).await.unwrap_err();
+    assert!(matches!(err, CloudError::RateLimit { .. }));
+}


### PR DESCRIPTION
Closes #96 

Adds `RetryProvider<P: LlmProvider>` — a zero-overhead wrapper that applies
exponential back-off to any LlmProvider implementation.

- `RetryConfig`: `max_attempts`, `initial_delay_ms`, `backoff_factor`, `max_delay_ms`
- Retries transient errors (`RateLimit`, `Network`, `Provider { retryable: true }`)
- Respects `RateLimit { retry_after }` hint — sleeps the server-specified duration
- Non-transient errors propagate immediately without retry
- `stream()` retries initial connection; once streaming, passes events through
- 8 unit tests using stub providers — no credentials needed, all pass in CI
- No new dependencies