### PR TITLE
feat(gcp): add Pub/Sub subscription management

### DIFF
--- a/examples/gcp/app_services/pubsub_subscription.md
+++ b/examples/gcp/app_services/pubsub_subscription.md
@@ -1,0 +1,91 @@
+# GCP Pub/Sub Subscriptions — RustCloud Examples
+
+Manage Pub/Sub subscriptions via `GcpPubSubSubscription`.
+The existing `gcp_notification_service` handles **topics**; this module handles **subscriptions**.
+
+## Setup
+
+```rust
+use rustcloud::gcp::gcp_apis::app_services::gcp_pubsub_subscription::GcpPubSubSubscription;
+use std::collections::HashMap;
+
+let client = GcpPubSubSubscription::new();
+```
+
+**Required:** `GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json`
+
+---
+
+## Create a subscription
+
+```rust
+let mut req = HashMap::new();
+req.insert("Project".to_string(), "my-project".to_string());
+req.insert("Topic".to_string(), "my-topic".to_string());
+req.insert("Subscription".to_string(), "my-sub".to_string());
+req.insert("AckDeadlineSeconds".to_string(), "30".to_string());
+
+client.create_subscription(req).await?;
+```
+
+## List subscriptions
+
+```rust
+let mut req = HashMap::new();
+req.insert("Project".to_string(), "my-project".to_string());
+req.insert("PageSize".to_string(), "20".to_string());
+
+let result = client.list_subscriptions(req).await?;
+println!("{}", result["body"]);
+```
+
+## Pull messages (synchronous pull)
+
+```rust
+let mut req = HashMap::new();
+req.insert("Project".to_string(), "my-project".to_string());
+req.insert("Subscription".to_string(), "my-sub".to_string());
+req.insert("MaxMessages".to_string(), "10".to_string());
+
+let result = client.pull_messages(req).await?;
+println!("{}", result["body"]); // JSON with receivedMessages[] array
+```
+
+## Acknowledge messages
+
+After processing, ack the messages to remove them from the queue:
+
+```rust
+let ack_ids = vec![
+    "projects/my-project/subscriptions/my-sub:1".to_string(),
+    "projects/my-project/subscriptions/my-sub:2".to_string(),
+];
+
+client.acknowledge_messages("my-project", "my-sub", ack_ids).await?;
+```
+
+## Switch to push delivery
+
+```rust
+client.modify_push_config(
+    "my-project",
+    "my-sub",
+    Some("https://my-service.example.com/push"),
+).await?;
+```
+
+## Revert to pull delivery (clear push endpoint)
+
+```rust
+client.modify_push_config("my-project", "my-sub", None).await?;
+```
+
+## Delete a subscription
+
+```rust
+let mut req = HashMap::new();
+req.insert("Project".to_string(), "my-project".to_string());
+req.insert("Subscription".to_string(), "my-sub".to_string());
+
+client.delete_subscription(req).await?;
+```

--- a/rustcloud/src/gcp/gcp_apis/app_services/gcp_pubsub_subscription.rs
+++ b/rustcloud/src/gcp/gcp_apis/app_services/gcp_pubsub_subscription.rs
@@ -1,0 +1,237 @@
+use crate::gcp::gcp_apis::auth::gcp_auth::retrieve_token;
+use reqwest::{header::AUTHORIZATION, Client, Method};
+use serde_json::json;
+use std::collections::HashMap;
+
+const PUBSUB_BASE: &str = "https://pubsub.googleapis.com";
+
+#[derive(Debug, Clone)]
+pub struct GcpPubSubSubscription {
+    client: Client,
+}
+
+impl GcpPubSubSubscription {
+    pub fn new() -> Self {
+        Self {
+            client: Client::new(),
+        }
+    }
+
+    pub async fn create_subscription(
+        &self,
+        request: HashMap<String, String>,
+    ) -> Result<HashMap<String, String>, Box<dyn std::error::Error>> {
+        let project = request.get("Project").expect("Project is required");
+        let topic = request.get("Topic").expect("Topic is required");
+        let subscription = request
+            .get("Subscription")
+            .expect("Subscription is required");
+        let ack_deadline = request
+            .get("AckDeadlineSeconds")
+            .map(|s| s.parse::<u32>().unwrap_or(10))
+            .unwrap_or(10);
+
+        let url = format!(
+            "{}/v1/projects/{}/subscriptions/{}",
+            PUBSUB_BASE, project, subscription
+        );
+
+        let body = json!({
+            "topic": format!("projects/{}/topics/{}", project, topic),
+            "ackDeadlineSeconds": ack_deadline
+        })
+        .to_string();
+
+        let token = retrieve_token().await?;
+        let response = self
+            .client
+            .request(Method::PUT, &url)
+            .header("Content-Type", "application/json")
+            .header(AUTHORIZATION, format!("Bearer {}", token))
+            .body(body)
+            .send()
+            .await?;
+
+        let status = response.status().as_u16().to_string();
+        let body = response.text().await?;
+
+        let mut result = HashMap::new();
+        result.insert("status".to_string(), status);
+        result.insert("body".to_string(), body);
+        Ok(result)
+    }
+
+    pub async fn delete_subscription(
+        &self,
+        request: HashMap<String, String>,
+    ) -> Result<HashMap<String, String>, Box<dyn std::error::Error>> {
+        let project = request.get("Project").expect("Project is required");
+        let subscription = request
+            .get("Subscription")
+            .expect("Subscription is required");
+
+        let url = format!(
+            "{}/v1/projects/{}/subscriptions/{}",
+            PUBSUB_BASE, project, subscription
+        );
+
+        let token = retrieve_token().await?;
+        let response = self
+            .client
+            .request(Method::DELETE, &url)
+            .header("Content-Type", "application/json")
+            .header(AUTHORIZATION, format!("Bearer {}", token))
+            .send()
+            .await?;
+
+        let status = response.status().as_u16().to_string();
+        let body = response.text().await?;
+
+        let mut result = HashMap::new();
+        result.insert("status".to_string(), status);
+        result.insert("body".to_string(), body);
+        Ok(result)
+    }
+
+    pub async fn list_subscriptions(
+        &self,
+        request: HashMap<String, String>,
+    ) -> Result<HashMap<String, String>, Box<dyn std::error::Error>> {
+        let project = request.get("Project").expect("Project is required");
+        let url = format!(
+            "{}/v1/projects/{}/subscriptions",
+            PUBSUB_BASE, project
+        );
+
+        let mut list_req = self.client.request(Method::GET, &url);
+
+        if let Some(page_size) = request.get("PageSize") {
+            list_req = list_req.query(&[("pageSize", page_size)]);
+        }
+        if let Some(page_token) = request.get("PageToken") {
+            list_req = list_req.query(&[("pageToken", page_token)]);
+        }
+
+        let token = retrieve_token().await?;
+        let response = list_req
+            .header("Content-Type", "application/json")
+            .header(AUTHORIZATION, format!("Bearer {}", token))
+            .send()
+            .await?;
+
+        let status = response.status().as_u16().to_string();
+        let body = response.text().await?;
+
+        let mut result = HashMap::new();
+        result.insert("status".to_string(), status);
+        result.insert("body".to_string(), body);
+        Ok(result)
+    }
+
+    pub async fn pull_messages(
+        &self,
+        request: HashMap<String, String>,
+    ) -> Result<HashMap<String, String>, Box<dyn std::error::Error>> {
+        let project = request.get("Project").expect("Project is required");
+        let subscription = request
+            .get("Subscription")
+            .expect("Subscription is required");
+        let max_messages = request
+            .get("MaxMessages")
+            .map(|s| s.parse::<u32>().unwrap_or(10))
+            .unwrap_or(10);
+
+        let url = format!(
+            "{}/v1/projects/{}/subscriptions/{}:pull",
+            PUBSUB_BASE, project, subscription
+        );
+
+        let body = json!({ "maxMessages": max_messages }).to_string();
+
+        let token = retrieve_token().await?;
+        let response = self
+            .client
+            .request(Method::POST, &url)
+            .header("Content-Type", "application/json")
+            .header(AUTHORIZATION, format!("Bearer {}", token))
+            .body(body)
+            .send()
+            .await?;
+
+        let status = response.status().as_u16().to_string();
+        let body = response.text().await?;
+
+        let mut result = HashMap::new();
+        result.insert("status".to_string(), status);
+        result.insert("body".to_string(), body);
+        Ok(result)
+    }
+
+    pub async fn acknowledge_messages(
+        &self,
+        project: &str,
+        subscription: &str,
+        ack_ids: Vec<String>,
+    ) -> Result<HashMap<String, String>, Box<dyn std::error::Error>> {
+        let url = format!(
+            "{}/v1/projects/{}/subscriptions/{}:acknowledge",
+            PUBSUB_BASE, project, subscription
+        );
+
+        let body = json!({ "ackIds": ack_ids }).to_string();
+
+        let token = retrieve_token().await?;
+        let response = self
+            .client
+            .request(Method::POST, &url)
+            .header("Content-Type", "application/json")
+            .header(AUTHORIZATION, format!("Bearer {}", token))
+            .body(body)
+            .send()
+            .await?;
+
+        let status = response.status().as_u16().to_string();
+        let body = response.text().await?;
+
+        let mut result = HashMap::new();
+        result.insert("status".to_string(), status);
+        result.insert("body".to_string(), body);
+        Ok(result)
+    }
+
+    pub async fn modify_push_config(
+        &self,
+        project: &str,
+        subscription: &str,
+        push_endpoint: Option<&str>,
+    ) -> Result<HashMap<String, String>, Box<dyn std::error::Error>> {
+        let url = format!(
+            "{}/v1/projects/{}/subscriptions/{}:modifyPushConfig",
+            PUBSUB_BASE, project, subscription
+        );
+
+        let push_config = match push_endpoint {
+            Some(ep) => json!({ "pushEndpoint": ep }),
+            None => json!({}),
+        };
+        let body = json!({ "pushConfig": push_config }).to_string();
+
+        let token = retrieve_token().await?;
+        let response = self
+            .client
+            .request(Method::POST, &url)
+            .header("Content-Type", "application/json")
+            .header(AUTHORIZATION, format!("Bearer {}", token))
+            .body(body)
+            .send()
+            .await?;
+
+        let status = response.status().as_u16().to_string();
+        let body = response.text().await?;
+
+        let mut result = HashMap::new();
+        result.insert("status".to_string(), status);
+        result.insert("body".to_string(), body);
+        Ok(result)
+    }
+}

--- a/rustcloud/src/tests/gcp_pubsub_subscription_operations.rs
+++ b/rustcloud/src/tests/gcp_pubsub_subscription_operations.rs
@@ -1,0 +1,82 @@
+use crate::gcp::gcp_apis::app_services::gcp_pubsub_subscription::*;
+use std::collections::HashMap;
+
+fn create_client() -> GcpPubSubSubscription {
+    GcpPubSubSubscription::new()
+}
+
+#[tokio::test]
+async fn test_create_subscription() {
+    let client = create_client();
+
+    let mut request = HashMap::new();
+    request.insert("Project".to_string(), "your_project_id".to_string());
+    request.insert("Topic".to_string(), "your_topic_name".to_string());
+    request.insert("Subscription".to_string(), "your_subscription".to_string());
+    request.insert("AckDeadlineSeconds".to_string(), "20".to_string());
+
+    let result = client.create_subscription(request).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_list_subscriptions() {
+    let client = create_client();
+
+    let mut request = HashMap::new();
+    request.insert("Project".to_string(), "your_project_id".to_string());
+    request.insert("PageSize".to_string(), "10".to_string());
+
+    let result = client.list_subscriptions(request).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_pull_messages() {
+    let client = create_client();
+
+    let mut request = HashMap::new();
+    request.insert("Project".to_string(), "your_project_id".to_string());
+    request.insert("Subscription".to_string(), "your_subscription".to_string());
+    request.insert("MaxMessages".to_string(), "5".to_string());
+
+    let result = client.pull_messages(request).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_acknowledge_messages() {
+    let client = create_client();
+    let ack_ids = vec!["ack_id_1".to_string(), "ack_id_2".to_string()];
+
+    let result = client
+        .acknowledge_messages("your_project_id", "your_subscription", ack_ids)
+        .await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_modify_push_config() {
+    let client = create_client();
+
+    let result = client
+        .modify_push_config(
+            "your_project_id",
+            "your_subscription",
+            Some("https://example.com/push"),
+        )
+        .await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_delete_subscription() {
+    let client = create_client();
+
+    let mut request = HashMap::new();
+    request.insert("Project".to_string(), "your_project_id".to_string());
+    request.insert("Subscription".to_string(), "your_subscription".to_string());
+
+    let result = client.delete_subscription(request).await;
+    assert!(result.is_ok());
+}


### PR DESCRIPTION
Closes #104 

## Summary
- Adds `gcp_pubsub_subscription.rs` — the consumer-side complement to the existing
  `gcp_notification_service.rs` which only handles topics
- 6 operations covering the full subscription lifecycle + message flow
- No new dependencies; uses existing `retrieve_token()` auth helper

## Operations
| Method | Endpoint |
|---|---|
| `create_subscription` | `PUT /v1/projects/{p}/subscriptions/{s}` |
| `delete_subscription` | `DELETE /v1/projects/{p}/subscriptions/{s}` |
| `list_subscriptions` | `GET /v1/projects/{p}/subscriptions` |
| `pull_messages` | `POST /v1/projects/{p}/subscriptions/{s}:pull` |
| `acknowledge_messages` | `POST /v1/projects/{p}/subscriptions/{s}:acknowledge` |
| `modify_push_config` | `POST /v1/projects/{p}/subscriptions/{s}:modifyPushConfig` |

## Test plan
- [x] `cargo build` passes with no new dependencies
- [x] `cargo test gcp_pubsub` runs without compile errors
- [x] Integration tests require `GOOGLE_APPLICATION_CREDENTIALS` set to a valid service account
