### PR TITLE
Fix DigitalOcean Kubernetes Module Export in Module Tree

### DIFF
--- a/rustcloud/src/main.rs
+++ b/rustcloud/src/main.rs
@@ -87,6 +87,9 @@ pub mod digiocean {
         pub mod dns {
             pub mod digiocean_dns;
         }
+        pub mod kubernetes {
+            pub mod digiocean_kubernetes;
+        }
         pub mod network {
             pub mod digiocean_loadbalancer;
         }


### PR DESCRIPTION


## Summary
- **What:** Exposed the DigitalOcean Kubernetes module in the public module tree so it can be imported and used.
- **Why:** The implementation existed but was not declared in the crate module hierarchy, making it inaccessible to consumers.
- **Related issue:** #115

## Changes
- Added the missing Kubernetes module block under DigitalOcean APIs in `main.rs`.
- Exported `digiocean_kubernetes` through the Kubernetes namespace.
- Verified compilation with `cargo check` and `cargo build --all-features`.

## Files Modified
- `main.rs`