### PR TITLE
Add rustfmt.toml for Consistent Rust Formatting

### DIFF
--- a/rustcloud/rustfmt.toml
+++ b/rustcloud/rustfmt.toml
@@ -1,0 +1,22 @@
+# Rust formatting configuration for RustCloud
+edition = "2021"
+
+# Code layout
+max_width = 100
+hard_tabs = false
+tab_spaces = 4
+
+# Imports
+# Keep imports organized consistently across modules.
+# Note: these import options currently require nightly rustfmt; stable will ignore them with warnings.
+imports_granularity = "Crate"
+group_imports = "StdExternalCrate"
+
+# Comments
+# Note: comment wrapping settings are nightly-only in rustfmt at the moment.
+wrap_comments = true
+comment_width = 100
+
+# Consistency
+# Normalize line endings regardless of contributor platform.
+newline_style = "Unix"


### PR DESCRIPTION
closes #114



## Summary
- **What:** Added a crate-level Rust formatter configuration file to standardize formatting behavior.
- **Why:** Ensure consistent formatting across contributors and reduce formatting-only churn in PRs.
- **Related issue:** Missing rustfmt configuration for project-specific formatting rules.

## Changes
- Added rustfmt configuration with edition, layout, import grouping, comment, and newline settings.
- Documented nightly-only rustfmt options inline to clarify stable behavior.
- Verified formatter run and kept this PR scoped to configuration only.

## Files Modified
- `rustfmt.toml`