### PR TITLE
Add Root .editorconfig for Consistent Editor Formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.rs]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+
+[*.toml]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+
+[*.md]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
closes #113 

## Summary
- **What:** Added a repository-level `.editorconfig` file with baseline formatting rules.
- **Why:** Ensure consistent formatting across editors and reduce style-only diffs in pull requests.
- **Related issue:** CONTRIBUTING references `.editorconfig`, but the file was missing.

## Changes
- Added global EditorConfig defaults (`utf-8`, final newline, trim trailing whitespace).
- Added Rust rules (4-space indentation, `lf` line endings).
- Added TOML rules (2-space indentation, `lf` line endings).
- Added Markdown rules (2-space indentation, preserve trailing whitespace).
- Added Makefile rule (tab indentation).

## Files Modified
- `.editorconfig`

