### PR TITLE
Remove Invalid language Block from Cargo Manifest

### DIFF
--- a/rustcloud/Cargo.toml
+++ b/rustcloud/Cargo.toml
@@ -41,10 +41,3 @@ tokio = { version = "1.37.0", features = ["full", "test-util"] }
 
 [dev-dependencies]
 rustcloud = { path = '.' }
-
-[[language]]
-name = "rust"
-file-types = ["rs"]
-comment-tokens = ["//", "///", "//!"]
-indent = { tab-width = 2, unit = " " }
-language-servers = [ "rust-analyzer"]


### PR DESCRIPTION
closes #112 
## Summary
- **What:** Removed the invalid `language`/editor configuration block from the Cargo manifest.
- **Why:** `language` is not part of the Cargo manifest schema and should not live in package metadata.
- **Related issue:** Fix invalid language section accidentally added to `Cargo.toml`.

## Changes
- Deleted the entire `language` block from the manifest.
- Kept all dependency and project configuration entries unchanged.
- Verified the crate still compiles with `cargo check`.

## Files Modified
- `Cargo.toml`