### PR TITLE
fix(digiocean): use CloudError instead of reqwest::Error

### DIFF
--- a/rustcloud/src/digiocean/digiocean_apis/compute/digiocean_droplet.rs
+++ b/rustcloud/src/digiocean/digiocean_apis/compute/digiocean_droplet.rs
@@ -1,3 +1,4 @@
+use crate::errors::CloudError;
 use reqwest::header::AUTHORIZATION;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -20,9 +21,9 @@ impl Droplet {
     pub async fn create_droplet(
         &self,
         request: HashMap<String, Value>,
-    ) -> Result<HashMap<String, Value>, reqwest::Error> {
+    ) -> Result<HashMap<String, Value>, CloudError> {
         let url = format!("{}/droplets", self.base_url);
-        let body = serde_json::to_string(&request).unwrap();
+        let body = serde_json::to_string(&request)?;
 
         let resp = self
             .client
@@ -46,7 +47,7 @@ impl Droplet {
     pub async fn delete_droplet(
         &self,
         droplet_id: &str,
-    ) -> Result<HashMap<String, Value>, reqwest::Error> {
+    ) -> Result<HashMap<String, Value>, CloudError> {
         let url = format!("{}/droplets/{}", self.base_url, droplet_id);
 
         let resp = self
@@ -66,7 +67,7 @@ impl Droplet {
         Ok(response)
     }
 
-    pub async fn list_droplets(&self) -> Result<HashMap<String, Value>, reqwest::Error> {
+    pub async fn list_droplets(&self) -> Result<HashMap<String, Value>, CloudError> {
         let url = format!("{}/droplets", self.base_url);
 
         let resp = self

--- a/rustcloud/src/digiocean/digiocean_apis/dns/digiocean_dns.rs
+++ b/rustcloud/src/digiocean/digiocean_apis/dns/digiocean_dns.rs
@@ -1,3 +1,4 @@
+use crate::errors::CloudError;
 use reqwest::header::AUTHORIZATION;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -20,9 +21,9 @@ impl DigiOceanDns {
     pub async fn create_domain(
         &self,
         request: HashMap<String, Value>,
-    ) -> Result<HashMap<String, Value>, reqwest::Error> {
+    ) -> Result<HashMap<String, Value>, CloudError> {
         let url = format!("{}/domains", self.base_url);
-        let body = serde_json::to_string(&request).unwrap();
+        let body = serde_json::to_string(&request)?;
 
         let resp = self
             .client
@@ -46,7 +47,7 @@ impl DigiOceanDns {
     pub async fn delete_domain(
         &self,
         domain_name: &str,
-    ) -> Result<HashMap<String, Value>, reqwest::Error> {
+    ) -> Result<HashMap<String, Value>, CloudError> {
         let url = format!("{}/domains/{}", self.base_url, domain_name);
 
         let resp = self

--- a/rustcloud/src/digiocean/digiocean_apis/kubernetes/digiocean_kubernetes.rs
+++ b/rustcloud/src/digiocean/digiocean_apis/kubernetes/digiocean_kubernetes.rs
@@ -1,3 +1,4 @@
+use crate::errors::CloudError;
 use reqwest::header::AUTHORIZATION;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -20,9 +21,9 @@ impl DigiOceanKubernetes {
     pub async fn create_cluster(
         &self,
         request: HashMap<String, Value>,
-    ) -> Result<HashMap<String, Value>, reqwest::Error> {
+    ) -> Result<HashMap<String, Value>, CloudError> {
         let url = format!("{}/kubernetes/clusters", self.base_url);
-        let body = serde_json::to_string(&request).unwrap();
+        let body = serde_json::to_string(&request)?;
 
         let resp = self
             .client
@@ -46,7 +47,7 @@ impl DigiOceanKubernetes {
     pub async fn delete_cluster(
         &self,
         cluster_id: &str,
-    ) -> Result<HashMap<String, Value>, reqwest::Error> {
+    ) -> Result<HashMap<String, Value>, CloudError> {
         let url = format!("{}/kubernetes/clusters/{}", self.base_url, cluster_id);
 
         let resp = self
@@ -66,7 +67,7 @@ impl DigiOceanKubernetes {
         Ok(response)
     }
 
-    pub async fn list_clusters(&self) -> Result<HashMap<String, Value>, reqwest::Error> {
+    pub async fn list_clusters(&self) -> Result<HashMap<String, Value>, CloudError> {
         let url = format!("{}/kubernetes/clusters", self.base_url);
 
         let resp = self
@@ -89,7 +90,7 @@ impl DigiOceanKubernetes {
     pub async fn get_cluster(
         &self,
         cluster_id: &str,
-    ) -> Result<HashMap<String, Value>, reqwest::Error> {
+    ) -> Result<HashMap<String, Value>, CloudError> {
         let url = format!("{}/kubernetes/clusters/{}", self.base_url, cluster_id);
 
         let resp = self
@@ -113,12 +114,12 @@ impl DigiOceanKubernetes {
         &self,
         cluster_id: &str,
         request: HashMap<String, Value>,
-    ) -> Result<HashMap<String, Value>, reqwest::Error> {
+    ) -> Result<HashMap<String, Value>, CloudError> {
         let url = format!(
             "{}/kubernetes/clusters/{}/node_pools",
             self.base_url, cluster_id
         );
-        let body = serde_json::to_string(&request).unwrap();
+        let body = serde_json::to_string(&request)?;
 
         let resp = self
             .client
@@ -143,7 +144,7 @@ impl DigiOceanKubernetes {
         &self,
         cluster_id: &str,
         pool_id: &str,
-    ) -> Result<HashMap<String, Value>, reqwest::Error> {
+    ) -> Result<HashMap<String, Value>, CloudError> {
         let url = format!(
             "{}/kubernetes/clusters/{}/node_pools/{}",
             self.base_url, cluster_id, pool_id
@@ -169,7 +170,7 @@ impl DigiOceanKubernetes {
     pub async fn get_kubeconfig(
         &self,
         cluster_id: &str,
-    ) -> Result<HashMap<String, Value>, reqwest::Error> {
+    ) -> Result<HashMap<String, Value>, CloudError> {
         let url = format!(
             "{}/kubernetes/clusters/{}/kubeconfig",
             self.base_url, cluster_id

--- a/rustcloud/src/digiocean/digiocean_apis/network/digiocean_loadbalancer.rs
+++ b/rustcloud/src/digiocean/digiocean_apis/network/digiocean_loadbalancer.rs
@@ -1,3 +1,4 @@
+use crate::errors::CloudError;
 use reqwest::header::AUTHORIZATION;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -20,9 +21,9 @@ impl DigiOceanLoadBalancer {
     pub async fn create_load_balancer(
         &self,
         request: HashMap<String, Value>,
-    ) -> Result<HashMap<String, Value>, reqwest::Error> {
+    ) -> Result<HashMap<String, Value>, CloudError> {
         let url = format!("{}/load_balancers", self.base_url);
-        let body = serde_json::to_string(&request).unwrap();
+        let body = serde_json::to_string(&request)?;
 
         let resp = self
             .client
@@ -46,7 +47,7 @@ impl DigiOceanLoadBalancer {
     pub async fn delete_load_balancer(
         &self,
         lb_id: &str,
-    ) -> Result<HashMap<String, Value>, reqwest::Error> {
+    ) -> Result<HashMap<String, Value>, CloudError> {
         let url = format!("{}/load_balancers/{}", self.base_url, lb_id);
 
         let resp = self

--- a/rustcloud/src/digiocean/digiocean_apis/storage/digiocean_storage.rs
+++ b/rustcloud/src/digiocean/digiocean_apis/storage/digiocean_storage.rs
@@ -1,3 +1,4 @@
+use crate::errors::CloudError;
 use reqwest::header::AUTHORIZATION;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -20,7 +21,7 @@ impl DigiOceanStorage {
     pub async fn create_volume(
         &self,
         request: HashMap<String, Value>,
-    ) -> Result<HashMap<String, Value>, reqwest::Error> {
+    ) -> Result<HashMap<String, Value>, CloudError> {
         let url = format!("{}/volumes", self.base_url);
         let body = serde_json::to_string(&request).unwrap();
 
@@ -46,7 +47,7 @@ impl DigiOceanStorage {
     pub async fn delete_volume(
         &self,
         volume_id: &str,
-    ) -> Result<HashMap<String, Value>, reqwest::Error> {
+    ) -> Result<HashMap<String, Value>, CloudError> {
         let url = format!("{}/volumes/{}", self.base_url, volume_id);
 
         let resp = self

--- a/rustcloud/src/errors.rs
+++ b/rustcloud/src/errors.rs
@@ -49,3 +49,15 @@ impl fmt::Display for CloudError {
 }
 
 impl std::error::Error for CloudError {}
+
+impl From<reqwest::Error> for CloudError {
+    fn from(err: reqwest::Error) -> Self {
+        CloudError::Network { source: err }
+    }
+}
+
+impl From<serde_json::Error> for CloudError {
+    fn from(err: serde_json::Error) -> Self {
+        CloudError::Serialization { source: err }
+    }
+}


### PR DESCRIPTION
## Summary
- Standardize DigitalOcean modules to return `CloudError` instead of `reqwest::Error`
- Added `From<reqwest::Error>` and `From<serde_json::Error>` implementations to `CloudError`
- Updated all DigitalOcean API modules: droplet, DNS, loadbalancer, storage, and Kubernetes