### PR TITLE
feat(vertex): honor system_prompt in requests

### DIFF
--- a/rustcloud/src/gcp/gcp_apis/artificial_intelligence/vertex.rs
+++ b/rustcloud/src/gcp/gcp_apis/artificial_intelligence/vertex.rs
@@ -56,13 +56,19 @@ impl LlmProvider for GoogleVertexAI {
             })
         }).collect::<Vec<_>>();
 
-        let body = json!({
+        let mut body = json!({
             "contents": contents,
             "generationConfig": {
                 "maxOutputTokens": req.max_tokens.unwrap_or(256),
                 "temperature": req.temperature.unwrap_or(0.7),
             }
         });
+
+        if let Some(ref system_prompt) = req.system_prompt {
+            body["systemInstruction"] = json!({
+                "parts": [{ "text": system_prompt }]
+            });
+        }
 
         let response = self.client.post(&url)
             .header(AUTHORIZATION, format!("Bearer {}", token))


### PR DESCRIPTION
## Summary
- Add support for `system_prompt` field in Vertex AI `generate` requests
- System prompt is now sent as `systemInstruction` in the API request body
- Previously the field was being silently ignored