### PR TITLE
feat(aws-bedrock): add BedrockProvider scaffold with module wiring

### DIFF
--- a/rustcloud/Cargo.toml
+++ b/rustcloud/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 async-trait = "0.1.80"
 aws-config = "1.4.0"
+aws-sdk-bedrockruntime = "1.30.0"
 aws-sdk-cloudwatch = "1.33.0"
 aws-sdk-config = "1.34.0"
 aws-sdk-docdb = "1.30.0"

--- a/rustcloud/src/aws/aws_apis/artificial_intelligence/aws_bedrock.rs
+++ b/rustcloud/src/aws/aws_apis/artificial_intelligence/aws_bedrock.rs
@@ -1,0 +1,56 @@
+use async_trait::async_trait;
+use aws_sdk_bedrockruntime::Client;
+
+use crate::errors::CloudError;
+use crate::traits::llm_provider::{LlmProvider, LlmStream};
+use crate::types::llm::{
+    EmbedResponse, LlmRequest, LlmResponse, ToolCallResponse, ToolDefinition,
+};
+
+pub struct BedrockProvider {
+    client: Client,
+}
+
+impl BedrockProvider {
+    pub async fn new() -> Self {
+        let config = aws_config::load_from_env().await;
+        Self {
+            client: Client::new(&config),
+        }
+    }
+
+    pub fn with_client(client: Client) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl LlmProvider for BedrockProvider {
+    async fn generate(&self, _req: LlmRequest) -> Result<LlmResponse, CloudError> {
+        Err(CloudError::Unsupported {
+            feature: "Bedrock generate",
+        })
+    }
+
+    async fn stream(&self, _req: LlmRequest) -> Result<LlmStream, CloudError> {
+        Err(CloudError::Unsupported {
+            feature: "Bedrock stream",
+        })
+    }
+
+    async fn embed(&self, _texts: Vec<String>) -> Result<EmbedResponse, CloudError> {
+        Err(CloudError::Unsupported {
+            feature: "Bedrock embed",
+        })
+    }
+
+    async fn generate_with_tools(
+        &self,
+        _req: LlmRequest,
+        _tools: Vec<ToolDefinition>,
+    ) -> Result<ToolCallResponse, CloudError> {
+        Err(CloudError::Unsupported {
+            feature: "Bedrock generate_with_tools",
+        })
+    }
+}

--- a/rustcloud/src/main.rs
+++ b/rustcloud/src/main.rs
@@ -21,6 +21,9 @@ pub mod azure{
 }
 pub mod aws {
     pub mod aws_apis {
+        pub mod artificial_intelligence {
+            pub mod aws_bedrock;
+        }
         pub mod compute {
             pub mod aws_ec2;
             pub mod aws_ecs;


### PR DESCRIPTION
Closes #139 

## What

Adds the initial `BedrockProvider` struct that will back the AWS Bedrock
`LlmProvider` implementation. All four trait methods are stubbed for now.

## Why

The `LlmProvider` trait in `src/traits/llm_provider.rs` has no concrete
AWS implementation on main. This PR lays the groundwork — correct struct,
constructors, module registration — so subsequent PRs can implement the
methods without touching the plumbing again.

## Changes

- `Cargo.toml`: add `aws-sdk-bedrockruntime = "1.30.0"`
- `src/aws/aws_apis/artificial_intelligence/aws_bedrock.rs`: new file
- `src/main.rs`: register `pub mod artificial_intelligence { pub mod aws_bedrock; }`

## Testing

`cargo check` passes. No runtime behaviour yet — methods return
`CloudError::Unsupported`. Unit tests land in the next PR alongside
`generate()`.

## Checklist

- [x] `cargo check` clean
- [x] No new warnings introduced
- [x] Follows existing module layout (`main.rs` inline declarations)
