### PR TITLE
feat(aws-bedrock): implement embed() via Titan Embed v2 invoke_model

### DIFF
--- a/rustcloud/Cargo.toml
+++ b/rustcloud/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 async-trait = "0.1.80"
 aws-config = "1.4.0"
+aws-sdk-bedrockruntime = "1.30.0"
 aws-sdk-cloudwatch = "1.33.0"
 aws-sdk-config = "1.34.0"
 aws-sdk-docdb = "1.30.0"

--- a/rustcloud/src/aws/aws_apis/artificial_intelligence/aws_bedrock.rs
+++ b/rustcloud/src/aws/aws_apis/artificial_intelligence/aws_bedrock.rs
@@ -1,10 +1,15 @@
 use async_trait::async_trait;
 use aws_sdk_bedrockruntime::Client;
+use aws_sdk_bedrockruntime::types::{
+    ContentBlock, ConversationRole, ConverseOutput as ConverseOutputKind,
+    InferenceConfiguration, Message as BedrockMessage, StopReason, SystemContentBlock,
+};
 
 use crate::errors::CloudError;
 use crate::traits::llm_provider::{LlmProvider, LlmStream};
 use crate::types::llm::{
-    EmbedResponse, LlmRequest, LlmResponse, ToolCallResponse, ToolDefinition,
+    EmbedResponse, FinishReason, LlmRequest, LlmResponse, ModelRef,
+    ToolCallResponse, ToolDefinition, UsageStats,
 };
 
 pub struct BedrockProvider {
@@ -24,11 +29,112 @@ impl BedrockProvider {
     }
 }
 
+pub(crate) fn extract_model_id(model: &ModelRef) -> Result<String, CloudError> {
+    match model {
+        ModelRef::Provider(id) => Ok(id.clone()),
+        ModelRef::Logical { family, tier } => Ok(match tier.as_deref() {
+            Some(t) => format!("{}.{}", family, t),
+            None => family.clone(),
+        }),
+        ModelRef::Deployment(_) => Err(CloudError::Unsupported {
+            feature: "Bedrock does not use deployment names; use ModelRef::Provider",
+        }),
+    }
+}
+
+pub(crate) fn build_messages(req: &LlmRequest) -> Result<Vec<BedrockMessage>, CloudError> {
+    req.messages
+        .iter()
+        .map(|msg| {
+            let role = if msg.role == "assistant" {
+                ConversationRole::Assistant
+            } else {
+                ConversationRole::User
+            };
+            BedrockMessage::builder()
+                .role(role)
+                .content(ContentBlock::Text(msg.content.clone()))
+                .build()
+                .map_err(|e| CloudError::Provider {
+                    http_status: 0,
+                    message: e.to_string(),
+                    retryable: false,
+                })
+        })
+        .collect()
+}
+
+pub(crate) fn build_inference_config(req: &LlmRequest) -> InferenceConfiguration {
+    let mut builder = InferenceConfiguration::builder();
+    if let Some(max_tokens) = req.max_tokens {
+        builder = builder.max_tokens(max_tokens as i32);
+    }
+    if let Some(temp) = req.temperature {
+        builder = builder.temperature(temp);
+    }
+    builder.build()
+}
+
+pub(crate) fn map_stop_reason(reason: &StopReason) -> FinishReason {
+    match reason {
+        StopReason::EndTurn => FinishReason::Stop,
+        StopReason::MaxTokens => FinishReason::Length,
+        StopReason::ToolUse => FinishReason::ToolCall,
+        other => FinishReason::Other(other.as_str().to_string()),
+    }
+}
+
 #[async_trait]
 impl LlmProvider for BedrockProvider {
-    async fn generate(&self, _req: LlmRequest) -> Result<LlmResponse, CloudError> {
-        Err(CloudError::Unsupported {
-            feature: "Bedrock generate",
+    async fn generate(&self, req: LlmRequest) -> Result<LlmResponse, CloudError> {
+        let model_id = extract_model_id(&req.model)?;
+        let messages = build_messages(&req)?;
+        let inference_config = build_inference_config(&req);
+
+        let mut builder = self.client.converse().model_id(&model_id);
+
+        for msg in messages {
+            builder = builder.messages(msg);
+        }
+
+        if let Some(system) = &req.system_prompt {
+            builder = builder.system(SystemContentBlock::Text(system.clone()));
+        }
+
+        builder = builder.inference_config(inference_config);
+
+        let response = builder.send().await.map_err(|e| CloudError::Provider {
+            http_status: 500,
+            message: e.to_string(),
+            retryable: false,
+        })?;
+
+        let finish_reason = map_stop_reason(response.stop_reason());
+
+        let text = match response.output() {
+            Some(ConverseOutputKind::Message(msg)) => msg
+                .content()
+                .iter()
+                .find_map(|block| {
+                    if let ContentBlock::Text(t) = block {
+                        Some(t.clone())
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or_default(),
+            _ => String::new(),
+        };
+
+        let usage = response.usage().map(|u| UsageStats {
+            prompt_tokens: u.input_tokens() as u32,
+            completion_tokens: u.output_tokens() as u32,
+        });
+
+        Ok(LlmResponse {
+            text,
+            finish_reason,
+            usage,
         })
     }
 

--- a/rustcloud/src/aws/aws_apis/artificial_intelligence/aws_bedrock.rs
+++ b/rustcloud/src/aws/aws_apis/artificial_intelligence/aws_bedrock.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use aws_sdk_bedrockruntime::Client;
+use aws_sdk_bedrockruntime::primitives::Blob;
 use aws_sdk_bedrockruntime::types::{
     ContentBlock, ConversationRole, ConverseOutput as ConverseOutputKind,
     InferenceConfiguration, Message as BedrockMessage, StopReason, SystemContentBlock,
@@ -84,6 +85,11 @@ pub(crate) fn map_stop_reason(reason: &StopReason) -> FinishReason {
     }
 }
 
+pub(crate) fn parse_embed_response(json: &serde_json::Value) -> Result<Vec<f32>, CloudError> {
+    serde_json::from_value(json["embedding"].clone())
+        .map_err(|e| CloudError::Serialization { source: e })
+}
+
 #[async_trait]
 impl LlmProvider for BedrockProvider {
     async fn generate(&self, req: LlmRequest) -> Result<LlmResponse, CloudError> {
@@ -144,10 +150,37 @@ impl LlmProvider for BedrockProvider {
         })
     }
 
-    async fn embed(&self, _texts: Vec<String>) -> Result<EmbedResponse, CloudError> {
-        Err(CloudError::Unsupported {
-            feature: "Bedrock embed",
-        })
+    async fn embed(&self, texts: Vec<String>) -> Result<EmbedResponse, CloudError> {
+        if texts.is_empty() {
+            return Ok(EmbedResponse { embeddings: vec![] });
+        }
+
+        let mut embeddings = Vec::with_capacity(texts.len());
+
+        for text in &texts {
+            let body_bytes = serde_json::to_vec(&serde_json::json!({"inputText": text}))
+                .map_err(|e| CloudError::Serialization { source: e })?;
+
+            let resp = self
+                .client
+                .invoke_model()
+                .model_id("amazon.titan-embed-text-v2:0")
+                .body(Blob::new(body_bytes))
+                .send()
+                .await
+                .map_err(|e| CloudError::Provider {
+                    http_status: 500,
+                    message: e.to_string(),
+                    retryable: false,
+                })?;
+
+            let resp_json: serde_json::Value = serde_json::from_slice(resp.body().as_ref())
+                .map_err(|e| CloudError::Serialization { source: e })?;
+
+            embeddings.push(parse_embed_response(&resp_json)?);
+        }
+
+        Ok(EmbedResponse { embeddings })
     }
 
     async fn generate_with_tools(

--- a/rustcloud/src/aws/aws_apis/artificial_intelligence/aws_bedrock.rs
+++ b/rustcloud/src/aws/aws_apis/artificial_intelligence/aws_bedrock.rs
@@ -1,0 +1,56 @@
+use async_trait::async_trait;
+use aws_sdk_bedrockruntime::Client;
+
+use crate::errors::CloudError;
+use crate::traits::llm_provider::{LlmProvider, LlmStream};
+use crate::types::llm::{
+    EmbedResponse, LlmRequest, LlmResponse, ToolCallResponse, ToolDefinition,
+};
+
+pub struct BedrockProvider {
+    client: Client,
+}
+
+impl BedrockProvider {
+    pub async fn new() -> Self {
+        let config = aws_config::load_from_env().await;
+        Self {
+            client: Client::new(&config),
+        }
+    }
+
+    pub fn with_client(client: Client) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl LlmProvider for BedrockProvider {
+    async fn generate(&self, _req: LlmRequest) -> Result<LlmResponse, CloudError> {
+        Err(CloudError::Unsupported {
+            feature: "Bedrock generate",
+        })
+    }
+
+    async fn stream(&self, _req: LlmRequest) -> Result<LlmStream, CloudError> {
+        Err(CloudError::Unsupported {
+            feature: "Bedrock stream",
+        })
+    }
+
+    async fn embed(&self, _texts: Vec<String>) -> Result<EmbedResponse, CloudError> {
+        Err(CloudError::Unsupported {
+            feature: "Bedrock embed",
+        })
+    }
+
+    async fn generate_with_tools(
+        &self,
+        _req: LlmRequest,
+        _tools: Vec<ToolDefinition>,
+    ) -> Result<ToolCallResponse, CloudError> {
+        Err(CloudError::Unsupported {
+            feature: "Bedrock generate_with_tools",
+        })
+    }
+}

--- a/rustcloud/src/main.rs
+++ b/rustcloud/src/main.rs
@@ -21,6 +21,9 @@ pub mod azure{
 }
 pub mod aws {
     pub mod aws_apis {
+        pub mod artificial_intelligence {
+            pub mod aws_bedrock;
+        }
         pub mod compute {
             pub mod aws_ec2;
             pub mod aws_ecs;

--- a/rustcloud/src/tests/aws_bedrock_operations.rs
+++ b/rustcloud/src/tests/aws_bedrock_operations.rs
@@ -1,0 +1,175 @@
+use crate::aws::aws_apis::artificial_intelligence::aws_bedrock::{
+    build_inference_config, build_messages, extract_model_id, map_stop_reason,
+};
+use crate::errors::CloudError;
+use crate::types::llm::{LlmRequest, Message, ModelRef};
+use aws_sdk_bedrockruntime::types::StopReason;
+
+fn make_request(model: ModelRef, messages: Vec<Message>) -> LlmRequest {
+    LlmRequest {
+        model,
+        messages,
+        max_tokens: None,
+        temperature: None,
+        system_prompt: None,
+    }
+}
+
+fn user_msg(content: &str) -> Message {
+    Message {
+        role: "user".to_string(),
+        content: content.to_string(),
+    }
+}
+
+fn assistant_msg(content: &str) -> Message {
+    Message {
+        role: "assistant".to_string(),
+        content: content.to_string(),
+    }
+}
+
+// ----- extract_model_id -----
+
+#[test]
+fn test_extract_model_id_provider_passthrough() {
+    let id = "anthropic.claude-3-5-sonnet-20241022-v2:0".to_string();
+    let result = extract_model_id(&ModelRef::Provider(id.clone())).unwrap();
+    assert_eq!(result, id);
+}
+
+#[test]
+fn test_extract_model_id_logical_family_and_tier() {
+    let model = ModelRef::Logical {
+        family: "anthropic.claude-3".to_string(),
+        tier: Some("sonnet".to_string()),
+    };
+    assert_eq!(extract_model_id(&model).unwrap(), "anthropic.claude-3.sonnet");
+}
+
+#[test]
+fn test_extract_model_id_logical_family_only() {
+    let model = ModelRef::Logical {
+        family: "amazon.titan-text-express".to_string(),
+        tier: None,
+    };
+    assert_eq!(
+        extract_model_id(&model).unwrap(),
+        "amazon.titan-text-express"
+    );
+}
+
+#[test]
+fn test_extract_model_id_deployment_is_unsupported() {
+    let model = ModelRef::Deployment("my-bedrock-deployment".to_string());
+    let err = extract_model_id(&model).unwrap_err();
+    assert!(
+        matches!(err, CloudError::Unsupported { .. }),
+        "expected Unsupported, got {:?}",
+        err
+    );
+}
+
+// ----- map_stop_reason -----
+
+#[test]
+fn test_map_stop_reason_end_turn_maps_to_stop() {
+    let reason = map_stop_reason(&StopReason::EndTurn);
+    assert!(
+        matches!(reason, crate::types::llm::FinishReason::Stop),
+        "EndTurn should map to Stop"
+    );
+}
+
+#[test]
+fn test_map_stop_reason_max_tokens_maps_to_length() {
+    let reason = map_stop_reason(&StopReason::MaxTokens);
+    assert!(matches!(reason, crate::types::llm::FinishReason::Length));
+}
+
+#[test]
+fn test_map_stop_reason_tool_use_maps_to_tool_call() {
+    let reason = map_stop_reason(&StopReason::ToolUse);
+    assert!(matches!(reason, crate::types::llm::FinishReason::ToolCall));
+}
+
+#[test]
+fn test_map_stop_reason_unknown_maps_to_other() {
+    let reason = map_stop_reason(&StopReason::from("content_filtered"));
+    assert!(matches!(reason, crate::types::llm::FinishReason::Other(_)));
+}
+
+// ----- build_messages -----
+
+#[test]
+fn test_build_messages_single_user_succeeds() {
+    let req = make_request(
+        ModelRef::Provider("test".to_string()),
+        vec![user_msg("Hello, world!")],
+    );
+    let msgs = build_messages(&req).unwrap();
+    assert_eq!(msgs.len(), 1);
+}
+
+#[test]
+fn test_build_messages_preserves_message_count() {
+    let req = make_request(
+        ModelRef::Provider("test".to_string()),
+        vec![
+            user_msg("First message"),
+            assistant_msg("First reply"),
+            user_msg("Second message"),
+        ],
+    );
+    let msgs = build_messages(&req).unwrap();
+    assert_eq!(msgs.len(), 3);
+}
+
+#[test]
+fn test_build_messages_empty_input_returns_empty_vec() {
+    let req = make_request(ModelRef::Provider("test".to_string()), vec![]);
+    let msgs = build_messages(&req).unwrap();
+    assert!(msgs.is_empty());
+}
+
+// ----- build_inference_config -----
+
+#[test]
+fn test_build_inference_config_does_not_panic_with_all_fields() {
+    let req = LlmRequest {
+        model: ModelRef::Provider("test".to_string()),
+        messages: vec![],
+        max_tokens: Some(1024),
+        temperature: Some(0.7),
+        system_prompt: None,
+    };
+    let _ = build_inference_config(&req);
+}
+
+#[test]
+fn test_build_inference_config_does_not_panic_with_no_fields() {
+    let req = make_request(ModelRef::Provider("test".to_string()), vec![]);
+    let _ = build_inference_config(&req);
+}
+
+// ----- integration -----
+
+#[tokio::test]
+#[ignore]
+async fn test_generate_live_api() {
+    use crate::aws::aws_apis::artificial_intelligence::aws_bedrock::BedrockProvider;
+    use crate::traits::llm_provider::LlmProvider;
+
+    let provider = BedrockProvider::new().await;
+    let req = LlmRequest {
+        model: ModelRef::Provider(
+            "anthropic.claude-3-5-haiku-20241022-v1:0".to_string(),
+        ),
+        messages: vec![user_msg("Reply with the single word OK and nothing else.")],
+        max_tokens: Some(10),
+        temperature: Some(0.0),
+        system_prompt: None,
+    };
+    let result = provider.generate(req).await.unwrap();
+    assert!(!result.text.is_empty());
+}

--- a/rustcloud/src/tests/aws_bedrock_operations.rs
+++ b/rustcloud/src/tests/aws_bedrock_operations.rs
@@ -1,5 +1,5 @@
 use crate::aws::aws_apis::artificial_intelligence::aws_bedrock::{
-    build_inference_config, build_messages, extract_model_id, map_stop_reason,
+    build_inference_config, build_messages, extract_model_id, map_stop_reason, parse_embed_response,
 };
 use crate::errors::CloudError;
 use crate::types::llm::{LlmRequest, Message, ModelRef};
@@ -152,6 +152,40 @@ fn test_build_inference_config_does_not_panic_with_no_fields() {
     let _ = build_inference_config(&req);
 }
 
+// ----- parse_embed_response -----
+
+#[test]
+fn test_embed_single_text_returns_one_vector() {
+    let json = serde_json::json!({"embedding": [0.1f32, 0.2f32, 0.3f32], "inputTextTokenCount": 3});
+    let vector = parse_embed_response(&json).unwrap();
+    assert_eq!(vector.len(), 3);
+}
+
+#[test]
+fn test_embed_multiple_texts_returns_multiple_vectors() {
+    let responses = vec![
+        serde_json::json!({"embedding": [0.1f32, 0.2f32]}),
+        serde_json::json!({"embedding": [0.3f32, 0.4f32]}),
+    ];
+    let vectors: Vec<Vec<f32>> = responses
+        .iter()
+        .map(|j| parse_embed_response(j).unwrap())
+        .collect();
+    assert_eq!(vectors.len(), 2);
+    assert_eq!(vectors[0].len(), 2);
+    assert_eq!(vectors[1].len(), 2);
+}
+
+#[tokio::test]
+async fn test_embed_empty_input_returns_empty_vec() {
+    use crate::aws::aws_apis::artificial_intelligence::aws_bedrock::BedrockProvider;
+    use crate::traits::llm_provider::LlmProvider;
+
+    let provider = BedrockProvider::new().await;
+    let result = provider.embed(vec![]).await.unwrap();
+    assert!(result.embeddings.is_empty());
+}
+
 // ----- integration -----
 
 #[tokio::test]
@@ -172,4 +206,19 @@ async fn test_generate_live_api() {
     };
     let result = provider.generate(req).await.unwrap();
     assert!(!result.text.is_empty());
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_embed_live_api() {
+    use crate::aws::aws_apis::artificial_intelligence::aws_bedrock::BedrockProvider;
+    use crate::traits::llm_provider::LlmProvider;
+
+    let provider = BedrockProvider::new().await;
+    let result = provider
+        .embed(vec!["Rust programming language".to_string()])
+        .await
+        .unwrap();
+    assert_eq!(result.embeddings.len(), 1);
+    assert!(!result.embeddings[0].is_empty());
 }

--- a/rustcloud/src/tests/mod.rs
+++ b/rustcloud/src/tests/mod.rs
@@ -1,5 +1,6 @@
 mod azure_blob_operations;
 mod aws_archival_operations;
+mod aws_bedrock_operations;
 mod aws_block_operations;
 mod aws_bucket_operations;
 mod aws_dns_operations;


### PR DESCRIPTION
Closes #143 

## Summary
- Implements `embed()` in `BedrockProvider` using `invoke_model` with `amazon.titan-embed-text-v2:0`
- Adds `parse_embed_response` pure helper for unit-testable JSON extraction
- Empty input returns early without making any network call

## Test plan
- [x] `cargo test aws_bedrock` — 16 unit tests pass
- [x] `test_embed_empty_input_returns_empty_vec` — verifies early return, no credentials needed
- [x] `test_embed_live_api` — run manually with valid AWS credentials to confirm end-to-end

