### PR TITLE
feat(aws-bedrock): Add map_sdk_error and error classification helpers

### DIFF
--- a/rustcloud/Cargo.toml
+++ b/rustcloud/Cargo.toml
@@ -9,6 +9,8 @@ edition = "2021"
 async-trait = "0.1.80"
 aws-config = "1.4.0"
 aws-sdk-bedrockruntime = "1.30.0"
+aws-smithy-types = "1.4"
+
 aws-sdk-cloudwatch = "1.33.0"
 aws-sdk-config = "1.34.0"
 aws-sdk-docdb = "1.30.0"

--- a/rustcloud/Cargo.toml
+++ b/rustcloud/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 async-trait = "0.1.80"
 aws-config = "1.4.0"
+aws-sdk-bedrockruntime = "1.30.0"
 aws-sdk-cloudwatch = "1.33.0"
 aws-sdk-config = "1.34.0"
 aws-sdk-docdb = "1.30.0"

--- a/rustcloud/src/aws/aws_apis/artificial_intelligence/aws_bedrock.rs
+++ b/rustcloud/src/aws/aws_apis/artificial_intelligence/aws_bedrock.rs
@@ -1,10 +1,15 @@
 use async_trait::async_trait;
 use aws_sdk_bedrockruntime::Client;
+use aws_sdk_bedrockruntime::types::{
+    ContentBlock, ConversationRole, ConverseOutput as ConverseOutputKind,
+    InferenceConfiguration, Message as BedrockMessage, StopReason, SystemContentBlock,
+};
 
 use crate::errors::CloudError;
 use crate::traits::llm_provider::{LlmProvider, LlmStream};
 use crate::types::llm::{
-    EmbedResponse, LlmRequest, LlmResponse, ToolCallResponse, ToolDefinition,
+    EmbedResponse, FinishReason, LlmRequest, LlmResponse, ModelRef,
+    ToolCallResponse, ToolDefinition, UsageStats,
 };
 
 pub struct BedrockProvider {
@@ -24,11 +29,112 @@ impl BedrockProvider {
     }
 }
 
+pub(crate) fn extract_model_id(model: &ModelRef) -> Result<String, CloudError> {
+    match model {
+        ModelRef::Provider(id) => Ok(id.clone()),
+        ModelRef::Logical { family, tier } => Ok(match tier.as_deref() {
+            Some(t) => format!("{}.{}", family, t),
+            None => family.clone(),
+        }),
+        ModelRef::Deployment(_) => Err(CloudError::Unsupported {
+            feature: "Bedrock does not use deployment names; use ModelRef::Provider",
+        }),
+    }
+}
+
+pub(crate) fn build_messages(req: &LlmRequest) -> Result<Vec<BedrockMessage>, CloudError> {
+    req.messages
+        .iter()
+        .map(|msg| {
+            let role = if msg.role == "assistant" {
+                ConversationRole::Assistant
+            } else {
+                ConversationRole::User
+            };
+            BedrockMessage::builder()
+                .role(role)
+                .content(ContentBlock::Text(msg.content.clone()))
+                .build()
+                .map_err(|e| CloudError::Provider {
+                    http_status: 0,
+                    message: e.to_string(),
+                    retryable: false,
+                })
+        })
+        .collect()
+}
+
+pub(crate) fn build_inference_config(req: &LlmRequest) -> InferenceConfiguration {
+    let mut builder = InferenceConfiguration::builder();
+    if let Some(max_tokens) = req.max_tokens {
+        builder = builder.max_tokens(max_tokens as i32);
+    }
+    if let Some(temp) = req.temperature {
+        builder = builder.temperature(temp);
+    }
+    builder.build()
+}
+
+pub(crate) fn map_stop_reason(reason: &StopReason) -> FinishReason {
+    match reason {
+        StopReason::EndTurn => FinishReason::Stop,
+        StopReason::MaxTokens => FinishReason::Length,
+        StopReason::ToolUse => FinishReason::ToolCall,
+        other => FinishReason::Other(other.as_str().to_string()),
+    }
+}
+
 #[async_trait]
 impl LlmProvider for BedrockProvider {
-    async fn generate(&self, _req: LlmRequest) -> Result<LlmResponse, CloudError> {
-        Err(CloudError::Unsupported {
-            feature: "Bedrock generate",
+    async fn generate(&self, req: LlmRequest) -> Result<LlmResponse, CloudError> {
+        let model_id = extract_model_id(&req.model)?;
+        let messages = build_messages(&req)?;
+        let inference_config = build_inference_config(&req);
+
+        let mut builder = self.client.converse().model_id(&model_id);
+
+        for msg in messages {
+            builder = builder.messages(msg);
+        }
+
+        if let Some(system) = &req.system_prompt {
+            builder = builder.system(SystemContentBlock::Text(system.clone()));
+        }
+
+        builder = builder.inference_config(inference_config);
+
+        let response = builder.send().await.map_err(|e| CloudError::Provider {
+            http_status: 500,
+            message: e.to_string(),
+            retryable: false,
+        })?;
+
+        let finish_reason = map_stop_reason(response.stop_reason());
+
+        let text = match response.output() {
+            Some(ConverseOutputKind::Message(msg)) => msg
+                .content()
+                .iter()
+                .find_map(|block| {
+                    if let ContentBlock::Text(t) = block {
+                        Some(t.clone())
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or_default(),
+            _ => String::new(),
+        };
+
+        let usage = response.usage().map(|u| UsageStats {
+            prompt_tokens: u.input_tokens() as u32,
+            completion_tokens: u.output_tokens() as u32,
+        });
+
+        Ok(LlmResponse {
+            text,
+            finish_reason,
+            usage,
         })
     }
 

--- a/rustcloud/src/aws/aws_apis/artificial_intelligence/aws_bedrock.rs
+++ b/rustcloud/src/aws/aws_apis/artificial_intelligence/aws_bedrock.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use aws_sdk_bedrockruntime::Client;
+use aws_sdk_bedrockruntime::primitives::Blob;
 use aws_sdk_bedrockruntime::types::{
     ContentBlock, ConversationRole, ConverseOutput as ConverseOutputKind,
     InferenceConfiguration, Message as BedrockMessage, StopReason, SystemContentBlock,
@@ -84,6 +85,11 @@ pub(crate) fn map_stop_reason(reason: &StopReason) -> FinishReason {
     }
 }
 
+pub(crate) fn parse_embed_response(json: &serde_json::Value) -> Result<Vec<f32>, CloudError> {
+    serde_json::from_value(json["embedding"].clone())
+        .map_err(|e| CloudError::Serialization { source: e })
+}
+
 #[async_trait]
 impl LlmProvider for BedrockProvider {
     async fn generate(&self, req: LlmRequest) -> Result<LlmResponse, CloudError> {
@@ -144,10 +150,37 @@ impl LlmProvider for BedrockProvider {
         })
     }
 
-    async fn embed(&self, _texts: Vec<String>) -> Result<EmbedResponse, CloudError> {
-        Err(CloudError::Unsupported {
-            feature: "Bedrock embed",
-        })
+    async fn embed(&self, texts: Vec<String>) -> Result<EmbedResponse, CloudError> {
+        if texts.is_empty() {
+            return Ok(EmbedResponse { embeddings: vec![] });
+        }
+
+        let mut embeddings = Vec::with_capacity(texts.len());
+
+        for text in &texts {
+            let body_bytes = serde_json::to_vec(&serde_json::json!({"inputText": text}))
+                .map_err(|e| CloudError::Serialization { source: e })?;
+
+            let resp = self
+                .client
+                .invoke_model()
+                .model_id("amazon.titan-embed-text-v2:0")
+                .body(Blob::new(body_bytes))
+                .send()
+                .await
+                .map_err(|e| CloudError::Provider {
+                    http_status: 500,
+                    message: e.to_string(),
+                    retryable: false,
+                })?;
+
+            let resp_json: serde_json::Value = serde_json::from_slice(resp.body().as_ref())
+                .map_err(|e| CloudError::Serialization { source: e })?;
+
+            embeddings.push(parse_embed_response(&resp_json)?);
+        }
+
+        Ok(EmbedResponse { embeddings })
     }
 
     async fn generate_with_tools(

--- a/rustcloud/src/aws/aws_apis/artificial_intelligence/aws_bedrock.rs
+++ b/rustcloud/src/aws/aws_apis/artificial_intelligence/aws_bedrock.rs
@@ -1,0 +1,56 @@
+use async_trait::async_trait;
+use aws_sdk_bedrockruntime::Client;
+
+use crate::errors::CloudError;
+use crate::traits::llm_provider::{LlmProvider, LlmStream};
+use crate::types::llm::{
+    EmbedResponse, LlmRequest, LlmResponse, ToolCallResponse, ToolDefinition,
+};
+
+pub struct BedrockProvider {
+    client: Client,
+}
+
+impl BedrockProvider {
+    pub async fn new() -> Self {
+        let config = aws_config::load_from_env().await;
+        Self {
+            client: Client::new(&config),
+        }
+    }
+
+    pub fn with_client(client: Client) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl LlmProvider for BedrockProvider {
+    async fn generate(&self, _req: LlmRequest) -> Result<LlmResponse, CloudError> {
+        Err(CloudError::Unsupported {
+            feature: "Bedrock generate",
+        })
+    }
+
+    async fn stream(&self, _req: LlmRequest) -> Result<LlmStream, CloudError> {
+        Err(CloudError::Unsupported {
+            feature: "Bedrock stream",
+        })
+    }
+
+    async fn embed(&self, _texts: Vec<String>) -> Result<EmbedResponse, CloudError> {
+        Err(CloudError::Unsupported {
+            feature: "Bedrock embed",
+        })
+    }
+
+    async fn generate_with_tools(
+        &self,
+        _req: LlmRequest,
+        _tools: Vec<ToolDefinition>,
+    ) -> Result<ToolCallResponse, CloudError> {
+        Err(CloudError::Unsupported {
+            feature: "Bedrock generate_with_tools",
+        })
+    }
+}

--- a/rustcloud/src/aws/aws_apis/artificial_intelligence/aws_bedrock.rs
+++ b/rustcloud/src/aws/aws_apis/artificial_intelligence/aws_bedrock.rs
@@ -5,7 +5,9 @@ use aws_sdk_bedrockruntime::types::{
     ContentBlock, ContentBlockDelta as StreamDelta, ConversationRole,
     ConverseOutput as ConverseOutputKind, ConverseStreamOutput as StreamEvent,
     InferenceConfiguration, Message as BedrockMessage, StopReason, SystemContentBlock,
+    Tool, ToolConfiguration, ToolInputSchema, ToolSpecification,
 };
+use aws_smithy_types::{Document, Number as SmithyNumber};
 use futures::channel::mpsc;
 use futures::SinkExt;
 
@@ -108,6 +110,63 @@ pub(crate) fn map_stream_event(event: &StreamEvent) -> Option<LlmStreamEvent> {
         })),
         _ => None,
     }
+}
+
+pub(crate) fn json_to_document(val: serde_json::Value) -> Document {
+    match val {
+        serde_json::Value::Null => Document::Null,
+        serde_json::Value::Bool(b) => Document::Bool(b),
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                if i < 0 {
+                    Document::Number(SmithyNumber::NegInt(i))
+                } else {
+                    Document::Number(SmithyNumber::PosInt(i as u64))
+                }
+            } else {
+                Document::Number(SmithyNumber::Float(n.as_f64().unwrap_or(0.0)))
+            }
+        }
+        serde_json::Value::String(s) => Document::String(s),
+        serde_json::Value::Array(arr) => {
+            Document::Array(arr.into_iter().map(json_to_document).collect())
+        }
+        serde_json::Value::Object(map) => {
+            Document::Object(map.into_iter().map(|(k, v)| (k, json_to_document(v))).collect())
+        }
+    }
+}
+
+pub(crate) fn document_to_json(doc: Document) -> serde_json::Value {
+    match doc {
+        Document::Null => serde_json::Value::Null,
+        Document::Bool(b) => serde_json::Value::Bool(b),
+        Document::Number(n) => match n {
+            SmithyNumber::PosInt(u) => serde_json::json!(u),
+            SmithyNumber::NegInt(i) => serde_json::json!(i),
+            SmithyNumber::Float(f) => serde_json::json!(f),
+        },
+        Document::String(s) => serde_json::Value::String(s),
+        Document::Array(arr) => {
+            serde_json::Value::Array(arr.into_iter().map(document_to_json).collect())
+        }
+        Document::Object(map) => serde_json::Value::Object(
+            map.into_iter().map(|(k, v)| (k, document_to_json(v))).collect(),
+        ),
+    }
+}
+
+pub(crate) fn build_tool_spec(tool: &ToolDefinition) -> Result<ToolSpecification, CloudError> {
+    ToolSpecification::builder()
+        .name(&tool.name)
+        .description(&tool.description)
+        .input_schema(ToolInputSchema::Json(json_to_document(tool.parameters.clone())))
+        .build()
+        .map_err(|e| CloudError::Provider {
+            http_status: 0,
+            message: e.to_string(),
+            retryable: false,
+        })
 }
 
 #[async_trait]
@@ -253,11 +312,92 @@ impl LlmProvider for BedrockProvider {
 
     async fn generate_with_tools(
         &self,
-        _req: LlmRequest,
-        _tools: Vec<ToolDefinition>,
+        req: LlmRequest,
+        tools: Vec<ToolDefinition>,
     ) -> Result<ToolCallResponse, CloudError> {
-        Err(CloudError::Unsupported {
-            feature: "Bedrock generate_with_tools",
-        })
+        let model_id = extract_model_id(&req.model)?;
+        let messages = build_messages(&req)?;
+        let inference_config = build_inference_config(&req);
+
+        let tool_specs: Vec<Tool> = tools
+            .iter()
+            .map(|t| build_tool_spec(t).map(Tool::ToolSpec))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let tool_config = tool_specs
+            .into_iter()
+            .fold(ToolConfiguration::builder(), |b, t| b.tools(t))
+            .build()
+            .map_err(|e| CloudError::Provider {
+                http_status: 0,
+                message: e.to_string(),
+                retryable: false,
+            })?;
+
+        let mut builder = self.client.converse().model_id(&model_id);
+
+        for msg in messages {
+            builder = builder.messages(msg);
+        }
+
+        if let Some(system) = &req.system_prompt {
+            builder = builder.system(SystemContentBlock::Text(system.clone()));
+        }
+
+        builder = builder.inference_config(inference_config);
+        builder = builder.tool_config(tool_config);
+
+        let response = builder.send().await.map_err(|e| CloudError::Provider {
+            http_status: 500,
+            message: e.to_string(),
+            retryable: false,
+        })?;
+
+        let finish_reason = map_stop_reason(response.stop_reason());
+
+        if matches!(finish_reason, FinishReason::ToolCall) {
+            if let Some(ConverseOutputKind::Message(msg)) = response.output() {
+                for block in msg.content() {
+                    if let ContentBlock::ToolUse(tool_use) = block {
+                        return Ok(ToolCallResponse::ToolCall {
+                            name: tool_use.name().to_string(),
+                            arguments: document_to_json(tool_use.input().clone()),
+                        });
+                    }
+                }
+            }
+            return Err(CloudError::Provider {
+                http_status: 500,
+                message: "stop_reason was tool_use but response contained no ToolUse block"
+                    .to_string(),
+                retryable: false,
+            });
+        }
+
+        let text = match response.output() {
+            Some(ConverseOutputKind::Message(msg)) => msg
+                .content()
+                .iter()
+                .find_map(|block| {
+                    if let ContentBlock::Text(t) = block {
+                        Some(t.clone())
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or_default(),
+            _ => String::new(),
+        };
+
+        let usage = response.usage().map(|u| UsageStats {
+            prompt_tokens: u.input_tokens() as u32,
+            completion_tokens: u.output_tokens() as u32,
+        });
+
+        Ok(ToolCallResponse::Text(LlmResponse {
+            text,
+            finish_reason,
+            usage,
+        }))
     }
 }

--- a/rustcloud/src/aws/aws_apis/artificial_intelligence/aws_bedrock.rs
+++ b/rustcloud/src/aws/aws_apis/artificial_intelligence/aws_bedrock.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use aws_sdk_bedrockruntime::Client;
+use aws_sdk_bedrockruntime::error::{ProvideErrorMetadata, SdkError};
 use aws_sdk_bedrockruntime::primitives::Blob;
 use aws_sdk_bedrockruntime::types::{
     ContentBlock, ContentBlockDelta as StreamDelta, ConversationRole,
@@ -32,6 +33,84 @@ impl BedrockProvider {
 
     pub fn with_client(client: Client) -> Self {
         Self { client }
+    }
+}
+
+pub(crate) fn classify_service_error(status: u16, code: &str, message: String) -> CloudError {
+    if status == 429 || code.contains("Throttling") {
+        return CloudError::RateLimit { retry_after: None };
+    }
+    if status == 403 || code.contains("AccessDenied") || status == 401 || code.contains("Unauthorized") {
+        return CloudError::Auth { message };
+    }
+    if status == 400 || code.contains("Validation") {
+        return CloudError::Provider { http_status: status, message, retryable: false };
+    }
+    if status == 503 || code.contains("ServiceUnavailable") {
+        return CloudError::Provider { http_status: status, message, retryable: true };
+    }
+    if status == 408 || code.contains("ModelTimeout") {
+        return CloudError::Provider { http_status: status, message, retryable: true };
+    }
+    if status == 424 || code.contains("ModelError") {
+        return CloudError::Provider { http_status: status, message, retryable: false };
+    }
+    CloudError::Provider {
+        http_status: status,
+        message,
+        retryable: status >= 500,
+    }
+}
+
+pub(crate) fn map_sdk_error<E: ProvideErrorMetadata>(err: SdkError<E>) -> CloudError {
+    match err {
+        SdkError::ServiceError(ctx) => {
+            let status = ctx.raw().status().as_u16();
+            let code = ctx.err().code().unwrap_or("");
+            let message = ctx.err().message().unwrap_or("service error").to_string();
+            classify_service_error(status, code, message)
+        }
+        SdkError::TimeoutError(_) => CloudError::Provider {
+            http_status: 408,
+            message: "request timed out".to_string(),
+            retryable: true,
+        },
+        SdkError::DispatchFailure(e) => {
+            if e.is_timeout() {
+                CloudError::Provider {
+                    http_status: 408,
+                    message: "connection timed out".to_string(),
+                    retryable: true,
+                }
+            } else if e.is_io() {
+                CloudError::Provider {
+                    http_status: 503,
+                    message: "IO error during dispatch".to_string(),
+                    retryable: true,
+                }
+            } else {
+                CloudError::Provider {
+                    http_status: 503,
+                    message: "dispatch failure".to_string(),
+                    retryable: false,
+                }
+            }
+        }
+        SdkError::ResponseError(ctx) => CloudError::Provider {
+            http_status: ctx.raw().status().as_u16(),
+            message: "invalid response from service".to_string(),
+            retryable: false,
+        },
+        SdkError::ConstructionFailure(_) => CloudError::Provider {
+            http_status: 0,
+            message: "failed to construct request".to_string(),
+            retryable: false,
+        },
+        _ => CloudError::Provider {
+            http_status: 500,
+            message: "unknown SDK error".to_string(),
+            retryable: false,
+        },
     }
 }
 
@@ -188,11 +267,7 @@ impl LlmProvider for BedrockProvider {
 
         builder = builder.inference_config(inference_config);
 
-        let response = builder.send().await.map_err(|e| CloudError::Provider {
-            http_status: 500,
-            message: e.to_string(),
-            retryable: false,
-        })?;
+        let response = builder.send().await.map_err(map_sdk_error)?;
 
         let finish_reason = map_stop_reason(response.stop_reason());
 
@@ -240,11 +315,7 @@ impl LlmProvider for BedrockProvider {
 
         builder = builder.inference_config(inference_config);
 
-        let response = builder.send().await.map_err(|e| CloudError::Provider {
-            http_status: 500,
-            message: e.to_string(),
-            retryable: false,
-        })?;
+        let response = builder.send().await.map_err(map_sdk_error)?;
 
         let (mut tx, rx) = mpsc::channel::<LlmStreamEvent>(32);
         let mut event_stream = response.stream;
@@ -261,6 +332,8 @@ impl LlmProvider for BedrockProvider {
                     }
                     Ok(None) => break,
                     Err(e) => {
+                        // recv() errors carry RawMessage as the response type, not HttpResponse,
+                        // so map_sdk_error's signature doesn't match here.
                         let _ = tx
                             .send(LlmStreamEvent::Error(CloudError::Provider {
                                 http_status: 500,
@@ -295,11 +368,7 @@ impl LlmProvider for BedrockProvider {
                 .body(Blob::new(body_bytes))
                 .send()
                 .await
-                .map_err(|e| CloudError::Provider {
-                    http_status: 500,
-                    message: e.to_string(),
-                    retryable: false,
-                })?;
+                .map_err(map_sdk_error)?;
 
             let resp_json: serde_json::Value = serde_json::from_slice(resp.body().as_ref())
                 .map_err(|e| CloudError::Serialization { source: e })?;
@@ -347,11 +416,7 @@ impl LlmProvider for BedrockProvider {
         builder = builder.inference_config(inference_config);
         builder = builder.tool_config(tool_config);
 
-        let response = builder.send().await.map_err(|e| CloudError::Provider {
-            http_status: 500,
-            message: e.to_string(),
-            retryable: false,
-        })?;
+        let response = builder.send().await.map_err(map_sdk_error)?;
 
         let finish_reason = map_stop_reason(response.stop_reason());
 

--- a/rustcloud/src/aws/aws_apis/artificial_intelligence/aws_bedrock.rs
+++ b/rustcloud/src/aws/aws_apis/artificial_intelligence/aws_bedrock.rs
@@ -2,14 +2,17 @@ use async_trait::async_trait;
 use aws_sdk_bedrockruntime::Client;
 use aws_sdk_bedrockruntime::primitives::Blob;
 use aws_sdk_bedrockruntime::types::{
-    ContentBlock, ConversationRole, ConverseOutput as ConverseOutputKind,
+    ContentBlock, ContentBlockDelta as StreamDelta, ConversationRole,
+    ConverseOutput as ConverseOutputKind, ConverseStreamOutput as StreamEvent,
     InferenceConfiguration, Message as BedrockMessage, StopReason, SystemContentBlock,
 };
+use futures::channel::mpsc;
+use futures::SinkExt;
 
 use crate::errors::CloudError;
 use crate::traits::llm_provider::{LlmProvider, LlmStream};
 use crate::types::llm::{
-    EmbedResponse, FinishReason, LlmRequest, LlmResponse, ModelRef,
+    EmbedResponse, FinishReason, LlmRequest, LlmResponse, LlmStreamEvent, ModelRef,
     ToolCallResponse, ToolDefinition, UsageStats,
 };
 
@@ -90,6 +93,23 @@ pub(crate) fn parse_embed_response(json: &serde_json::Value) -> Result<Vec<f32>,
         .map_err(|e| CloudError::Serialization { source: e })
 }
 
+pub(crate) fn map_stream_event(event: &StreamEvent) -> Option<LlmStreamEvent> {
+    match event {
+        StreamEvent::ContentBlockDelta(e) => match e.delta() {
+            Some(StreamDelta::Text(t)) => Some(LlmStreamEvent::DeltaText(t.clone())),
+            _ => None,
+        },
+        StreamEvent::MessageStop(e) => {
+            Some(LlmStreamEvent::Done(map_stop_reason(e.stop_reason())))
+        }
+        StreamEvent::Metadata(e) => e.usage().map(|u| LlmStreamEvent::Usage(UsageStats {
+            prompt_tokens: u.input_tokens() as u32,
+            completion_tokens: u.output_tokens() as u32,
+        })),
+        _ => None,
+    }
+}
+
 #[async_trait]
 impl LlmProvider for BedrockProvider {
     async fn generate(&self, req: LlmRequest) -> Result<LlmResponse, CloudError> {
@@ -144,10 +164,58 @@ impl LlmProvider for BedrockProvider {
         })
     }
 
-    async fn stream(&self, _req: LlmRequest) -> Result<LlmStream, CloudError> {
-        Err(CloudError::Unsupported {
-            feature: "Bedrock stream",
-        })
+    async fn stream(&self, req: LlmRequest) -> Result<LlmStream, CloudError> {
+        let model_id = extract_model_id(&req.model)?;
+        let messages = build_messages(&req)?;
+        let inference_config = build_inference_config(&req);
+
+        let mut builder = self.client.converse_stream().model_id(&model_id);
+
+        for msg in messages {
+            builder = builder.messages(msg);
+        }
+
+        if let Some(system) = &req.system_prompt {
+            builder = builder.system(SystemContentBlock::Text(system.clone()));
+        }
+
+        builder = builder.inference_config(inference_config);
+
+        let response = builder.send().await.map_err(|e| CloudError::Provider {
+            http_status: 500,
+            message: e.to_string(),
+            retryable: false,
+        })?;
+
+        let (mut tx, rx) = mpsc::channel::<LlmStreamEvent>(32);
+        let mut event_stream = response.stream;
+
+        tokio::spawn(async move {
+            loop {
+                match event_stream.recv().await {
+                    Ok(Some(event)) => {
+                        if let Some(mapped) = map_stream_event(&event) {
+                            if tx.send(mapped).await.is_err() {
+                                break;
+                            }
+                        }
+                    }
+                    Ok(None) => break,
+                    Err(e) => {
+                        let _ = tx
+                            .send(LlmStreamEvent::Error(CloudError::Provider {
+                                http_status: 500,
+                                message: e.to_string(),
+                                retryable: true,
+                            }))
+                            .await;
+                        break;
+                    }
+                }
+            }
+        });
+
+        Ok(Box::pin(rx))
     }
 
     async fn embed(&self, texts: Vec<String>) -> Result<EmbedResponse, CloudError> {

--- a/rustcloud/src/main.rs
+++ b/rustcloud/src/main.rs
@@ -21,6 +21,9 @@ pub mod azure{
 }
 pub mod aws {
     pub mod aws_apis {
+        pub mod artificial_intelligence {
+            pub mod aws_bedrock;
+        }
         pub mod compute {
             pub mod aws_ec2;
             pub mod aws_ecs;

--- a/rustcloud/src/tests/aws_bedrock_operations.rs
+++ b/rustcloud/src/tests/aws_bedrock_operations.rs
@@ -1,5 +1,6 @@
 use crate::aws::aws_apis::artificial_intelligence::aws_bedrock::{
-    build_inference_config, build_messages, extract_model_id, map_stop_reason, parse_embed_response,
+    build_inference_config, build_messages, extract_model_id, map_stop_reason,
+    map_stream_event, parse_embed_response,
 };
 use crate::errors::CloudError;
 use crate::types::llm::{LlmRequest, Message, ModelRef};
@@ -186,6 +187,97 @@ async fn test_embed_empty_input_returns_empty_vec() {
     assert!(result.embeddings.is_empty());
 }
 
+// ----- map_stream_event -----
+
+#[test]
+fn test_map_stream_event_text_delta_maps_to_delta_text() {
+    use aws_sdk_bedrockruntime::types::{
+        ContentBlockDelta, ContentBlockDeltaEvent, ConverseStreamOutput,
+    };
+
+    let event = ConverseStreamOutput::ContentBlockDelta(
+        ContentBlockDeltaEvent::builder()
+            .content_block_index(0)
+            .delta(ContentBlockDelta::Text("hello".to_string()))
+            .build()
+            .unwrap(),
+    );
+    let result = map_stream_event(&event);
+    assert!(
+        matches!(result, Some(crate::types::llm::LlmStreamEvent::DeltaText(ref t)) if t == "hello"),
+        "expected DeltaText(\"hello\"), got {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_map_stream_event_message_stop_maps_to_done() {
+    use aws_sdk_bedrockruntime::types::{ConverseStreamOutput, MessageStopEvent};
+
+    let event = ConverseStreamOutput::MessageStop(
+        MessageStopEvent::builder()
+            .stop_reason(StopReason::EndTurn)
+            .build()
+            .unwrap(),
+    );
+    let result = map_stream_event(&event);
+    assert!(
+        matches!(
+            result,
+            Some(crate::types::llm::LlmStreamEvent::Done(
+                crate::types::llm::FinishReason::Stop
+            ))
+        ),
+        "expected Done(Stop), got {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_map_stream_event_metadata_maps_to_usage() {
+    use aws_sdk_bedrockruntime::types::{
+        ConverseStreamMetadataEvent, ConverseStreamOutput, TokenUsage,
+    };
+
+    let usage = TokenUsage::builder()
+        .input_tokens(10)
+        .output_tokens(20)
+        .total_tokens(30)
+        .build()
+        .unwrap();
+    let event = ConverseStreamOutput::Metadata(
+        ConverseStreamMetadataEvent::builder()
+            .usage(usage)
+            .build(),
+    );
+    let result = map_stream_event(&event);
+    assert!(
+        matches!(
+            result,
+            Some(crate::types::llm::LlmStreamEvent::Usage(ref u))
+                if u.prompt_tokens == 10 && u.completion_tokens == 20
+        ),
+        "expected Usage(10, 20), got {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_map_stream_event_non_content_event_returns_none() {
+    use aws_sdk_bedrockruntime::types::{ContentBlockStopEvent, ConverseStreamOutput};
+
+    let event = ConverseStreamOutput::ContentBlockStop(
+        ContentBlockStopEvent::builder()
+            .content_block_index(0)
+            .build()
+            .unwrap(),
+    );
+    assert!(
+        map_stream_event(&event).is_none(),
+        "ContentBlockStop should return None"
+    );
+}
+
 // ----- integration -----
 
 #[tokio::test]
@@ -221,4 +313,30 @@ async fn test_embed_live_api() {
         .unwrap();
     assert_eq!(result.embeddings.len(), 1);
     assert!(!result.embeddings[0].is_empty());
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_stream_live_api() {
+    use crate::aws::aws_apis::artificial_intelligence::aws_bedrock::BedrockProvider;
+    use crate::traits::llm_provider::LlmProvider;
+    use crate::types::llm::LlmStreamEvent;
+    use futures::StreamExt;
+
+    let provider = BedrockProvider::new().await;
+    let req = LlmRequest {
+        model: ModelRef::Provider("anthropic.claude-3-5-haiku-20241022-v1:0".to_string()),
+        messages: vec![user_msg("Reply with the single word OK and nothing else.")],
+        max_tokens: Some(10),
+        temperature: Some(0.0),
+        system_prompt: None,
+    };
+    let mut stream = provider.stream(req).await.unwrap();
+    let mut got_text = false;
+    while let Some(event) = stream.next().await {
+        if matches!(event, LlmStreamEvent::DeltaText(_)) {
+            got_text = true;
+        }
+    }
+    assert!(got_text);
 }

--- a/rustcloud/src/tests/aws_bedrock_operations.rs
+++ b/rustcloud/src/tests/aws_bedrock_operations.rs
@@ -1,0 +1,175 @@
+use crate::aws::aws_apis::artificial_intelligence::aws_bedrock::{
+    build_inference_config, build_messages, extract_model_id, map_stop_reason,
+};
+use crate::errors::CloudError;
+use crate::types::llm::{LlmRequest, Message, ModelRef};
+use aws_sdk_bedrockruntime::types::StopReason;
+
+fn make_request(model: ModelRef, messages: Vec<Message>) -> LlmRequest {
+    LlmRequest {
+        model,
+        messages,
+        max_tokens: None,
+        temperature: None,
+        system_prompt: None,
+    }
+}
+
+fn user_msg(content: &str) -> Message {
+    Message {
+        role: "user".to_string(),
+        content: content.to_string(),
+    }
+}
+
+fn assistant_msg(content: &str) -> Message {
+    Message {
+        role: "assistant".to_string(),
+        content: content.to_string(),
+    }
+}
+
+// ----- extract_model_id -----
+
+#[test]
+fn test_extract_model_id_provider_passthrough() {
+    let id = "anthropic.claude-3-5-sonnet-20241022-v2:0".to_string();
+    let result = extract_model_id(&ModelRef::Provider(id.clone())).unwrap();
+    assert_eq!(result, id);
+}
+
+#[test]
+fn test_extract_model_id_logical_family_and_tier() {
+    let model = ModelRef::Logical {
+        family: "anthropic.claude-3".to_string(),
+        tier: Some("sonnet".to_string()),
+    };
+    assert_eq!(extract_model_id(&model).unwrap(), "anthropic.claude-3.sonnet");
+}
+
+#[test]
+fn test_extract_model_id_logical_family_only() {
+    let model = ModelRef::Logical {
+        family: "amazon.titan-text-express".to_string(),
+        tier: None,
+    };
+    assert_eq!(
+        extract_model_id(&model).unwrap(),
+        "amazon.titan-text-express"
+    );
+}
+
+#[test]
+fn test_extract_model_id_deployment_is_unsupported() {
+    let model = ModelRef::Deployment("my-bedrock-deployment".to_string());
+    let err = extract_model_id(&model).unwrap_err();
+    assert!(
+        matches!(err, CloudError::Unsupported { .. }),
+        "expected Unsupported, got {:?}",
+        err
+    );
+}
+
+// ----- map_stop_reason -----
+
+#[test]
+fn test_map_stop_reason_end_turn_maps_to_stop() {
+    let reason = map_stop_reason(&StopReason::EndTurn);
+    assert!(
+        matches!(reason, crate::types::llm::FinishReason::Stop),
+        "EndTurn should map to Stop"
+    );
+}
+
+#[test]
+fn test_map_stop_reason_max_tokens_maps_to_length() {
+    let reason = map_stop_reason(&StopReason::MaxTokens);
+    assert!(matches!(reason, crate::types::llm::FinishReason::Length));
+}
+
+#[test]
+fn test_map_stop_reason_tool_use_maps_to_tool_call() {
+    let reason = map_stop_reason(&StopReason::ToolUse);
+    assert!(matches!(reason, crate::types::llm::FinishReason::ToolCall));
+}
+
+#[test]
+fn test_map_stop_reason_unknown_maps_to_other() {
+    let reason = map_stop_reason(&StopReason::from("content_filtered"));
+    assert!(matches!(reason, crate::types::llm::FinishReason::Other(_)));
+}
+
+// ----- build_messages -----
+
+#[test]
+fn test_build_messages_single_user_succeeds() {
+    let req = make_request(
+        ModelRef::Provider("test".to_string()),
+        vec![user_msg("Hello, world!")],
+    );
+    let msgs = build_messages(&req).unwrap();
+    assert_eq!(msgs.len(), 1);
+}
+
+#[test]
+fn test_build_messages_preserves_message_count() {
+    let req = make_request(
+        ModelRef::Provider("test".to_string()),
+        vec![
+            user_msg("First message"),
+            assistant_msg("First reply"),
+            user_msg("Second message"),
+        ],
+    );
+    let msgs = build_messages(&req).unwrap();
+    assert_eq!(msgs.len(), 3);
+}
+
+#[test]
+fn test_build_messages_empty_input_returns_empty_vec() {
+    let req = make_request(ModelRef::Provider("test".to_string()), vec![]);
+    let msgs = build_messages(&req).unwrap();
+    assert!(msgs.is_empty());
+}
+
+// ----- build_inference_config -----
+
+#[test]
+fn test_build_inference_config_does_not_panic_with_all_fields() {
+    let req = LlmRequest {
+        model: ModelRef::Provider("test".to_string()),
+        messages: vec![],
+        max_tokens: Some(1024),
+        temperature: Some(0.7),
+        system_prompt: None,
+    };
+    let _ = build_inference_config(&req);
+}
+
+#[test]
+fn test_build_inference_config_does_not_panic_with_no_fields() {
+    let req = make_request(ModelRef::Provider("test".to_string()), vec![]);
+    let _ = build_inference_config(&req);
+}
+
+// ----- integration -----
+
+#[tokio::test]
+#[ignore]
+async fn test_generate_live_api() {
+    use crate::aws::aws_apis::artificial_intelligence::aws_bedrock::BedrockProvider;
+    use crate::traits::llm_provider::LlmProvider;
+
+    let provider = BedrockProvider::new().await;
+    let req = LlmRequest {
+        model: ModelRef::Provider(
+            "anthropic.claude-3-5-haiku-20241022-v1:0".to_string(),
+        ),
+        messages: vec![user_msg("Reply with the single word OK and nothing else.")],
+        max_tokens: Some(10),
+        temperature: Some(0.0),
+        system_prompt: None,
+    };
+    let result = provider.generate(req).await.unwrap();
+    assert!(!result.text.is_empty());
+}

--- a/rustcloud/src/tests/aws_bedrock_operations.rs
+++ b/rustcloud/src/tests/aws_bedrock_operations.rs
@@ -1,5 +1,5 @@
 use crate::aws::aws_apis::artificial_intelligence::aws_bedrock::{
-    build_inference_config, build_messages, extract_model_id, map_stop_reason,
+    build_inference_config, build_messages, extract_model_id, map_stop_reason, parse_embed_response,
 };
 use crate::errors::CloudError;
 use crate::types::llm::{LlmRequest, Message, ModelRef};
@@ -152,6 +152,40 @@ fn test_build_inference_config_does_not_panic_with_no_fields() {
     let _ = build_inference_config(&req);
 }
 
+// ----- parse_embed_response -----
+
+#[test]
+fn test_embed_single_text_returns_one_vector() {
+    let json = serde_json::json!({"embedding": [0.1f32, 0.2f32, 0.3f32], "inputTextTokenCount": 3});
+    let vector = parse_embed_response(&json).unwrap();
+    assert_eq!(vector.len(), 3);
+}
+
+#[test]
+fn test_embed_multiple_texts_returns_multiple_vectors() {
+    let responses = vec![
+        serde_json::json!({"embedding": [0.1f32, 0.2f32]}),
+        serde_json::json!({"embedding": [0.3f32, 0.4f32]}),
+    ];
+    let vectors: Vec<Vec<f32>> = responses
+        .iter()
+        .map(|j| parse_embed_response(j).unwrap())
+        .collect();
+    assert_eq!(vectors.len(), 2);
+    assert_eq!(vectors[0].len(), 2);
+    assert_eq!(vectors[1].len(), 2);
+}
+
+#[tokio::test]
+async fn test_embed_empty_input_returns_empty_vec() {
+    use crate::aws::aws_apis::artificial_intelligence::aws_bedrock::BedrockProvider;
+    use crate::traits::llm_provider::LlmProvider;
+
+    let provider = BedrockProvider::new().await;
+    let result = provider.embed(vec![]).await.unwrap();
+    assert!(result.embeddings.is_empty());
+}
+
 // ----- integration -----
 
 #[tokio::test]
@@ -172,4 +206,19 @@ async fn test_generate_live_api() {
     };
     let result = provider.generate(req).await.unwrap();
     assert!(!result.text.is_empty());
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_embed_live_api() {
+    use crate::aws::aws_apis::artificial_intelligence::aws_bedrock::BedrockProvider;
+    use crate::traits::llm_provider::LlmProvider;
+
+    let provider = BedrockProvider::new().await;
+    let result = provider
+        .embed(vec!["Rust programming language".to_string()])
+        .await
+        .unwrap();
+    assert_eq!(result.embeddings.len(), 1);
+    assert!(!result.embeddings[0].is_empty());
 }

--- a/rustcloud/src/tests/aws_bedrock_operations.rs
+++ b/rustcloud/src/tests/aws_bedrock_operations.rs
@@ -1,9 +1,9 @@
 use crate::aws::aws_apis::artificial_intelligence::aws_bedrock::{
-    build_inference_config, build_messages, extract_model_id, map_stop_reason,
-    map_stream_event, parse_embed_response,
+    build_inference_config, build_messages, build_tool_spec, document_to_json,
+    extract_model_id, json_to_document, map_stop_reason, map_stream_event, parse_embed_response,
 };
 use crate::errors::CloudError;
-use crate::types::llm::{LlmRequest, Message, ModelRef};
+use crate::types::llm::{LlmRequest, Message, ModelRef, ToolDefinition};
 use aws_sdk_bedrockruntime::types::StopReason;
 
 fn make_request(model: ModelRef, messages: Vec<Message>) -> LlmRequest {
@@ -182,7 +182,10 @@ async fn test_embed_empty_input_returns_empty_vec() {
     use crate::aws::aws_apis::artificial_intelligence::aws_bedrock::BedrockProvider;
     use crate::traits::llm_provider::LlmProvider;
 
-    let provider = BedrockProvider::new().await;
+    let config = aws_sdk_bedrockruntime::Config::builder()
+        .behavior_version(aws_sdk_bedrockruntime::config::BehaviorVersion::latest())
+        .build();
+    let provider = BedrockProvider::with_client(aws_sdk_bedrockruntime::Client::from_conf(config));
     let result = provider.embed(vec![]).await.unwrap();
     assert!(result.embeddings.is_empty());
 }
@@ -278,6 +281,40 @@ fn test_map_stream_event_non_content_event_returns_none() {
     );
 }
 
+// ----- json_to_document / document_to_json -----
+
+#[test]
+fn test_json_to_document_preserves_string() {
+    let val = serde_json::json!("hello");
+    assert_eq!(document_to_json(json_to_document(val.clone())), val);
+}
+
+#[test]
+fn test_json_to_document_preserves_object() {
+    let val = serde_json::json!({"type": "object", "count": 3, "active": true});
+    assert_eq!(document_to_json(json_to_document(val.clone())), val);
+}
+
+#[test]
+fn test_document_round_trip_nested() {
+    let val = serde_json::json!({"nested": {"arr": [1, 2, 3], "flag": false}});
+    assert_eq!(document_to_json(json_to_document(val.clone())), val);
+}
+
+// ----- build_tool_spec -----
+
+#[test]
+fn test_build_tool_spec_sets_name_and_description() {
+    let tool = ToolDefinition {
+        name: "weather".to_string(),
+        description: "Get current weather".to_string(),
+        parameters: serde_json::json!({"type": "object", "properties": {}}),
+    };
+    let spec = build_tool_spec(&tool).unwrap();
+    assert_eq!(spec.name(), "weather");
+    assert_eq!(spec.description(), Some("Get current weather"));
+}
+
 // ----- integration -----
 
 #[tokio::test]
@@ -339,4 +376,34 @@ async fn test_stream_live_api() {
         }
     }
     assert!(got_text);
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_generate_with_tools_live_api() {
+    use crate::aws::aws_apis::artificial_intelligence::aws_bedrock::BedrockProvider;
+    use crate::traits::llm_provider::LlmProvider;
+    use crate::types::llm::ToolCallResponse;
+
+    let provider = BedrockProvider::new().await;
+    let req = LlmRequest {
+        model: ModelRef::Provider("anthropic.claude-3-5-haiku-20241022-v1:0".to_string()),
+        messages: vec![user_msg("What is the weather in London?")],
+        max_tokens: Some(256),
+        temperature: Some(0.0),
+        system_prompt: None,
+    };
+    let tools = vec![ToolDefinition {
+        name: "get_weather".to_string(),
+        description: "Get the current weather for a location".to_string(),
+        parameters: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "location": {"type": "string", "description": "City name"}
+            },
+            "required": ["location"]
+        }),
+    }];
+    let result = provider.generate_with_tools(req, tools).await.unwrap();
+    assert!(matches!(result, ToolCallResponse::ToolCall { .. }));
 }

--- a/rustcloud/src/tests/mod.rs
+++ b/rustcloud/src/tests/mod.rs
@@ -1,5 +1,6 @@
 mod azure_blob_operations;
 mod aws_archival_operations;
+mod aws_bedrock_operations;
 mod aws_block_operations;
 mod aws_bucket_operations;
 mod aws_dns_operations;


### PR DESCRIPTION
Closes #149 

## Summary

- Adds `classify_service_error(status, code, message)` — pure classification logic mapping HTTP status + AWS error code to the right `CloudError` variant
- Adds `map_sdk_error<E>(err: SdkError<E>)` — extracts real HTTP status from `ServiceError.raw().status()`, routes Timeout/Dispatch/ResponseError/ConstructionFailure to appropriate variants
- Replaces all four hardcoded `CloudError::Provider { http_status: 500 }` in `generate`, `stream`, `embed`, `generate_with_tools`
- Both helpers are `pub(crate)` for direct unit testing

## Test plan
- [x] `cargo test aws_bedrock` passes (24/24 unit)
