### PR TITLE
feat(gcp): add Vertex AI embed support and TokenProvider injection

### DIFF
--- a/rustcloud/src/gcp/gcp_apis/artificial_intelligence/gcp_vertex_ai.rs
+++ b/rustcloud/src/gcp/gcp_apis/artificial_intelligence/gcp_vertex_ai.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
@@ -7,8 +9,9 @@ use reqwest::header::AUTHORIZATION;
 use tokio::sync::Mutex;
 
 use crate::errors::CloudError;
-use crate::gcp::gcp_apis::auth::gcp_auth::retrieve_token;
+use crate::gcp::gcp_apis::auth::gcp_auth::ServiceAccountTokenProvider;
 use crate::traits::llm_provider::{LlmProvider, LlmStream};
+use crate::traits::token_provider::TokenProvider;
 use crate::types::llm::{
     EmbedResponse, FinishReason, LlmRequest, LlmResponse, LlmStreamEvent, ModelRef,
     ToolCallResponse, ToolDefinition, UsageStats,
@@ -23,6 +26,7 @@ pub struct VertexAiProvider {
     http: reqwest::Client,
     project: String,
     location: String,
+    auth: Arc<dyn TokenProvider>,
     token: Mutex<CachedToken>,
 }
 
@@ -33,13 +37,21 @@ impl VertexAiProvider {
     ) -> Result<Self, CloudError> {
         let project = project.into();
         let location = location.into();
-        let token = retrieve_token().await.map_err(|e| CloudError::Auth {
+        let auth: Arc<dyn TokenProvider> = Arc::new(
+            ServiceAccountTokenProvider::new(
+                PathBuf::from("service-account.json"),
+                vec!["https://www.googleapis.com/auth/cloud-platform".to_string()],
+            )
+            .map_err(|e| CloudError::Auth { message: e.to_string() })?,
+        );
+        let token = auth.get_token().await.map_err(|e| CloudError::Auth {
             message: e.to_string(),
         })?;
         Ok(Self {
             http: reqwest::Client::new(),
             project,
             location,
+            auth,
             token: Mutex::new(CachedToken {
                 value: token,
                 expires_at: Instant::now() + Duration::from_secs(3600),
@@ -51,24 +63,25 @@ impl VertexAiProvider {
         http: reqwest::Client,
         project: impl Into<String>,
         location: impl Into<String>,
-        token: impl Into<String>,
+        auth: Arc<dyn TokenProvider>,
     ) -> Self {
         Self {
             http,
             project: project.into(),
             location: location.into(),
+            auth,
             token: Mutex::new(CachedToken {
-                value: token.into(),
-                // far-future expiry so tests never hit the real token refresh path
-                expires_at: Instant::now() + Duration::from_secs(86400 * 365),
+                value: String::new(),
+                // already expired so the first get_token() call fetches from auth
+                expires_at: Instant::now(),
             }),
         }
     }
 
-    async fn get_token(&self) -> Result<String, CloudError> {
+    pub(crate) async fn get_token(&self) -> Result<String, CloudError> {
         let mut cached = self.token.lock().await;
         if cached.expires_at.saturating_duration_since(Instant::now()) < Duration::from_secs(300) {
-            let fresh = retrieve_token().await.map_err(|e| CloudError::Auth {
+            let fresh = self.auth.get_token().await.map_err(|e| CloudError::Auth {
                 message: e.to_string(),
             })?;
             cached.value = fresh;
@@ -249,6 +262,32 @@ pub(crate) fn sse_chunk_to_events(json: &serde_json::Value) -> Vec<LlmStreamEven
     events
 }
 
+pub(crate) fn build_embed_request(texts: &[String]) -> serde_json::Value {
+    let instances: Vec<serde_json::Value> =
+        texts.iter().map(|t| serde_json::json!({ "content": t })).collect();
+    serde_json::json!({ "instances": instances })
+}
+
+pub(crate) fn parse_embed_response(json: &serde_json::Value) -> Result<EmbedResponse, CloudError> {
+    let predictions = json["predictions"].as_array().ok_or_else(|| CloudError::Provider {
+        http_status: 0,
+        message: "response missing predictions".to_string(),
+        retryable: false,
+    })?;
+
+    let mut embeddings = Vec::with_capacity(predictions.len());
+    for p in predictions {
+        let values = p["embeddings"]["values"].as_array().ok_or_else(|| CloudError::Provider {
+            http_status: 0,
+            message: "malformed embedding in response".to_string(),
+            retryable: false,
+        })?;
+        embeddings.push(values.iter().map(|v| v.as_f64().unwrap_or(0.0) as f32).collect());
+    }
+
+    Ok(EmbedResponse { embeddings })
+}
+
 #[async_trait]
 impl LlmProvider for VertexAiProvider {
     async fn generate(&self, req: LlmRequest) -> Result<LlmResponse, CloudError> {
@@ -343,8 +382,39 @@ impl LlmProvider for VertexAiProvider {
         Ok(Box::pin(rx))
     }
 
-    async fn embed(&self, _texts: Vec<String>) -> Result<EmbedResponse, CloudError> {
-        Err(CloudError::Unsupported { feature: "Vertex AI embed" })
+    async fn embed(&self, texts: Vec<String>) -> Result<EmbedResponse, CloudError> {
+        if texts.is_empty() {
+            return Ok(EmbedResponse { embeddings: vec![] });
+        }
+
+        let token = self.get_token().await?;
+        let url = vertex_endpoint(&self.project, &self.location, "text-embedding-004", "predict");
+        let body = build_embed_request(&texts);
+
+        let response = self
+            .http
+            .post(&url)
+            .header(AUTHORIZATION, format!("Bearer {}", token))
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| CloudError::Network { source: e })?;
+
+        let status = response.status().as_u16();
+        if status >= 400 {
+            let text = response.text().await.unwrap_or_default();
+            return Err(map_vertex_http_error(status, &text));
+        }
+
+        let bytes = response
+            .bytes()
+            .await
+            .map_err(|e| CloudError::Network { source: e })?;
+
+        let resp_json: serde_json::Value =
+            serde_json::from_slice(&bytes).map_err(|e| CloudError::Serialization { source: e })?;
+
+        parse_embed_response(&resp_json)
     }
 
     async fn generate_with_tools(

--- a/rustcloud/src/tests/gcp_vertex_ai_operations.rs
+++ b/rustcloud/src/tests/gcp_vertex_ai_operations.rs
@@ -1,16 +1,22 @@
+use std::sync::Arc;
+
 use crate::errors::CloudError;
 use crate::gcp::gcp_apis::artificial_intelligence::gcp_vertex_ai::{
     VertexAiProvider,
+    build_embed_request,
     build_vertex_request,
     extract_model_id,
     map_finish_reason,
     map_vertex_http_error,
+    parse_embed_response,
     parse_sse_line,
     parse_vertex_response,
     sse_chunk_to_events,
     vertex_endpoint,
 };
+use crate::gcp::gcp_apis::auth::gcp_auth::MockTokenProvider;
 use crate::traits::llm_provider::LlmProvider;
+use crate::traits::token_provider::TokenProvider;
 use crate::types::llm::{FinishReason, LlmRequest, LlmStreamEvent, Message, ModelRef};
 
 fn no_creds_provider() -> VertexAiProvider {
@@ -18,7 +24,7 @@ fn no_creds_provider() -> VertexAiProvider {
         reqwest::Client::new(),
         "test-project",
         "us-central1",
-        "fake-token",
+        Arc::new(MockTokenProvider::new("fake-token")),
     )
 }
 
@@ -366,17 +372,85 @@ fn test_sse_chunk_to_events_no_candidates_returns_empty() {
     assert!(sse_chunk_to_events(&json).is_empty());
 }
 
+// --- build_embed_request ---
+
+#[test]
+fn test_build_embed_request_single_text() {
+    let body = build_embed_request(&["hello".to_string()]);
+    assert_eq!(body["instances"][0]["content"], "hello");
+}
+
+#[test]
+fn test_build_embed_request_multiple_texts() {
+    let body = build_embed_request(&["a".to_string(), "b".to_string()]);
+    assert_eq!(body["instances"].as_array().unwrap().len(), 2);
+    assert_eq!(body["instances"][1]["content"], "b");
+}
+
+#[test]
+fn test_build_embed_request_empty() {
+    let body = build_embed_request(&[]);
+    assert_eq!(body["instances"], serde_json::json!([]));
+}
+
+// --- parse_embed_response ---
+
+#[test]
+fn test_parse_embed_response_single() {
+    let json = serde_json::json!({
+        "predictions": [{
+            "embeddings": { "values": [1.0, 2.0, 3.0] }
+        }]
+    });
+    let resp = parse_embed_response(&json).unwrap();
+    assert_eq!(resp.embeddings.len(), 1);
+    assert_eq!(resp.embeddings[0], vec![1.0f32, 2.0f32, 3.0f32]);
+}
+
+#[test]
+fn test_parse_embed_response_multiple() {
+    let json = serde_json::json!({
+        "predictions": [
+            { "embeddings": { "values": [1.0, 2.0] } },
+            { "embeddings": { "values": [3.0, 4.0] } }
+        ]
+    });
+    let resp = parse_embed_response(&json).unwrap();
+    assert_eq!(resp.embeddings.len(), 2);
+    assert_eq!(resp.embeddings[1], vec![3.0f32, 4.0f32]);
+}
+
+#[test]
+fn test_parse_embed_response_missing_predictions() {
+    let json = serde_json::json!({ "error": { "code": 401, "message": "unauthorized" } });
+    let err = parse_embed_response(&json).unwrap_err();
+    assert!(
+        matches!(err, CloudError::Provider { .. }),
+        "expected Provider error, got {:?}",
+        err
+    );
+}
+
+#[test]
+fn test_parse_embed_response_malformed_values() {
+    let json = serde_json::json!({
+        "predictions": [{ "embeddings": {} }]
+    });
+    let err = parse_embed_response(&json).unwrap_err();
+    assert!(
+        matches!(err, CloudError::Provider { .. }),
+        "expected Provider error, got {:?}",
+        err
+    );
+}
+
 // --- async unit tests (no live credentials) ---
 
 #[tokio::test]
-async fn test_embed_returns_unsupported() {
+async fn test_embed_empty_texts_returns_early() {
     let provider = no_creds_provider();
-    let err = provider.embed(vec!["hello".to_string()]).await.unwrap_err();
-    assert!(
-        matches!(err, CloudError::Unsupported { .. }),
-        "expected Unsupported, got {:?}",
-        err
-    );
+    let resp = provider.embed(vec![]).await.unwrap();
+    assert!(resp.embeddings.is_empty());
 }
 
 #[tokio::test]
@@ -400,7 +474,65 @@ async fn test_generate_with_tools_returns_unsupported() {
     );
 }
 
-// --- integration tests (require live GCP credentials) ---
+// --- token caching ---
+
+#[tokio::test]
+async fn test_get_token_refreshes_when_expired() {
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    struct CountingProvider {
+        count: Arc<AtomicU32>,
+        token: String,
+    }
+
+    #[async_trait::async_trait]
+    impl TokenProvider for CountingProvider {
+        async fn get_token(
+            &self,
+        ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+            self.count.fetch_add(1, Ordering::Relaxed);
+            Ok(self.token.clone())
+        }
+    }
+
+    let count = Arc::new(AtomicU32::new(0));
+    let auth = Arc::new(CountingProvider {
+        count: Arc::clone(&count),
+        token: "refreshed".to_string(),
+    });
+
+    // with_http_client sets expires_at = Instant::now(), so the first get_token() refreshes
+    let provider = VertexAiProvider::with_http_client(
+        reqwest::Client::new(),
+        "p",
+        "us-central1",
+        auth,
+    );
+
+    let token = provider.get_token().await.unwrap();
+    assert_eq!(token, "refreshed");
+    assert_eq!(count.load(Ordering::Relaxed), 1);
+
+    // second call is within TTL — no refresh
+    let _ = provider.get_token().await.unwrap();
+    assert_eq!(count.load(Ordering::Relaxed), 1);
+}
+
+// --- integration tests (require live GCP credentials, run with --ignored) ---
+
+#[tokio::test]
+#[ignore]
+async fn test_embed_live_api() {
+    let provider = VertexAiProvider::new("your-project-id", "us-central1")
+        .await
+        .expect("failed to create provider");
+    let resp = provider
+        .embed(vec!["Hello, world!".to_string()])
+        .await
+        .expect("embed failed");
+    assert_eq!(resp.embeddings.len(), 1);
+    assert!(!resp.embeddings[0].is_empty());
+}
 
 #[tokio::test]
 #[ignore]


### PR DESCRIPTION
Closes #158 

Refactored `VertexAiProvider` to hold `Arc<dyn TokenProvider>` instead of calling `retrieve_token()` directly. The production `new()` constructor creates a `ServiceAccountTokenProvider`; the new `with_http_client()` test constructor accepts any `TokenProvider` implementation. `get_token()` is now `pub(crate)` and handles proactive refresh (TTL < 5 min) with thundering-herd protection — the `tokio::sync::Mutex` is held across the async refresh call so concurrent requests don't all trigger a refresh simultaneously.

Implemented `embed()` using the `text-embedding-004:predict` endpoint. Added `pub(crate)` helpers `build_embed_request` and `parse_embed_response` for direct unit testing. Empty input returns early without a network round-trip.

45 tests pass.
