### PR TITLE
fix(gcp-bigquery): add CloudError handling and injectable auth

### DIFF
--- a/rustcloud/src/gcp/gcp_apis/database/gcp_bigquery.rs
+++ b/rustcloud/src/gcp/gcp_apis/database/gcp_bigquery.rs
@@ -1,95 +1,155 @@
-use crate::gcp::gcp_apis::auth::gcp_auth::retrieve_token;
-use crate::gcp::types::database::gcp_bigquery_types::*;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
 use reqwest::{header::AUTHORIZATION, Client};
-use serde_json::{json, to_string};
+use serde_json::json;
+use tokio::sync::Mutex;
+
+use crate::errors::CloudError;
+use crate::gcp::gcp_apis::auth::gcp_auth::ServiceAccountTokenProvider;
+use crate::gcp::types::database::gcp_bigquery_types::*;
+use crate::traits::token_provider::TokenProvider;
+use std::path::PathBuf;
+
+struct CachedToken {
+    value: String,
+    expires_at: Instant,
+}
 
 pub struct BigQuery {
     client: Client,
-    base_url: String,
     project_id: String,
+    auth: Arc<dyn TokenProvider>,
+    token: Mutex<CachedToken>,
 }
 
 impl BigQuery {
-    pub fn new(project_id: &str) -> Self {
-        Self {
+    pub async fn new(project_id: &str) -> Result<Self, CloudError> {
+        let auth: Arc<dyn TokenProvider> = Arc::new(
+            ServiceAccountTokenProvider::new(
+                PathBuf::from("service-account.json"),
+                vec!["https://www.googleapis.com/auth/cloud-platform".to_string()],
+            )
+            .map_err(|e| CloudError::Auth { message: e.to_string() })?,
+        );
+        let token = auth.get_token().await.map_err(|e| CloudError::Auth {
+            message: e.to_string(),
+        })?;
+        Ok(Self {
             client: Client::new(),
-            base_url: "https://bigquery.googleapis.com/bigquery/v2".to_string(),
             project_id: project_id.to_string(),
+            auth,
+            token: Mutex::new(CachedToken {
+                value: token,
+                expires_at: Instant::now() + Duration::from_secs(3600),
+            }),
+        })
+    }
+
+    pub fn with_http_client(
+        client: Client,
+        project_id: &str,
+        auth: Arc<dyn TokenProvider>,
+    ) -> Self {
+        Self {
+            client,
+            project_id: project_id.to_string(),
+            auth,
+            token: Mutex::new(CachedToken {
+                value: String::new(),
+                expires_at: Instant::now(),
+            }),
         }
     }
 
-    pub async fn create_dataset(
-        &self,
-        dataset_id: &str,
-    ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
-        let url = format!("{}/projects/{}/datasets", self.base_url, self.project_id);
+    pub(crate) async fn get_token(&self) -> Result<String, CloudError> {
+        let mut cached = self.token.lock().await;
+        if cached.expires_at.saturating_duration_since(Instant::now()) < Duration::from_secs(300) {
+            let fresh = self.auth.get_token().await.map_err(|e| CloudError::Auth {
+                message: e.to_string(),
+            })?;
+            cached.value = fresh;
+            cached.expires_at = Instant::now() + Duration::from_secs(3600);
+        }
+        Ok(cached.value.clone())
+    }
 
-        let body = to_string(&CreateDataset {
+    pub async fn create_dataset(&self, dataset_id: &str) -> Result<serde_json::Value, CloudError> {
+        let url = bigquery_url(&self.project_id, "datasets");
+        let body = CreateDataset {
             dataset_reference: DatasetReference {
                 project_id: self.project_id.clone(),
                 dataset_id: dataset_id.to_string(),
             },
-        })?;
+        };
+        let token = self.get_token().await?;
 
-        let token = retrieve_token().await?;
         let response = self
             .client
             .post(&url)
-            .body(body)
-            .header("Content-Type", "application/json")
+            .json(&body)
             .header(AUTHORIZATION, format!("Bearer {}", token))
             .send()
-            .await?;
+            .await
+            .map_err(|e| CloudError::Network { source: e })?;
 
-        let status = response.status();
-        let body = response.text().await?;
+        let status = response.status().as_u16();
+        let text = response.text().await.map_err(|e| CloudError::Network { source: e })?;
+        if status >= 400 {
+            return Err(map_bigquery_http_error(status, &text));
+        }
 
-        Ok(json!({ "status": status.as_u16(), "body": body }))
+        Ok(json!({ "status": status, "body": text }))
     }
 
     pub async fn delete_dataset(
         &self,
         dataset_id: &str,
         delete_contents: bool,
-    ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
+    ) -> Result<serde_json::Value, CloudError> {
         let url = format!(
-            "{}/projects/{}/datasets/{}?deleteContents={}",
-            self.base_url, self.project_id, dataset_id, delete_contents
+            "{}?deleteContents={}",
+            bigquery_url(&self.project_id, &format!("datasets/{}", dataset_id)),
+            delete_contents
         );
+        let token = self.get_token().await?;
 
-        let token = retrieve_token().await?;
         let response = self
             .client
             .delete(&url)
-            .header("Content-Type", "application/json")
             .header(AUTHORIZATION, format!("Bearer {}", token))
             .send()
-            .await?;
+            .await
+            .map_err(|e| CloudError::Network { source: e })?;
 
-        let status = response.status();
-        let body = response.text().await?;
+        let status = response.status().as_u16();
+        let text = response.text().await.map_err(|e| CloudError::Network { source: e })?;
+        if status >= 400 {
+            return Err(map_bigquery_http_error(status, &text));
+        }
 
-        Ok(json!({ "status": status.as_u16(), "body": body }))
+        Ok(json!({ "status": status, "body": text }))
     }
 
-    pub async fn list_datasets(
-        &self,
-    ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
-        let url = format!("{}/projects/{}/datasets", self.base_url, self.project_id);
+    pub async fn list_datasets(&self) -> Result<serde_json::Value, CloudError> {
+        let url = bigquery_url(&self.project_id, "datasets");
+        let token = self.get_token().await?;
 
-        let token = retrieve_token().await?;
         let response = self
             .client
             .get(&url)
-            .header("Content-Type", "application/json")
             .header(AUTHORIZATION, format!("Bearer {}", token))
             .send()
-            .await?;
+            .await
+            .map_err(|e| CloudError::Network { source: e })?;
 
-        let status = response.status();
-        let body = response.text().await?;
+        let status = response.status().as_u16();
+        let text = response.text().await.map_err(|e| CloudError::Network { source: e })?;
+        if status >= 400 {
+            return Err(map_bigquery_http_error(status, &text));
+        }
 
-        Ok(json!({ "status": status.as_u16(), "body": body }))
+        Ok(json!({ "status": status, "body": text }))
     }
 
     pub async fn create_table(
@@ -97,110 +157,218 @@ impl BigQuery {
         dataset_id: &str,
         table_id: &str,
         fields: Vec<TableField>,
-    ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
-        let url = format!(
-            "{}/projects/{}/datasets/{}/tables",
-            self.base_url, self.project_id, dataset_id
-        );
-
-        let body = to_string(&CreateTable {
+    ) -> Result<serde_json::Value, CloudError> {
+        let url = bigquery_url(&self.project_id, &format!("datasets/{}/tables", dataset_id));
+        let body = CreateTable {
             table_reference: TableReference {
                 project_id: self.project_id.clone(),
                 dataset_id: dataset_id.to_string(),
                 table_id: table_id.to_string(),
             },
             schema: TableSchema { fields },
-        })?;
+        };
+        let token = self.get_token().await?;
 
-        let token = retrieve_token().await?;
         let response = self
             .client
             .post(&url)
-            .body(body)
-            .header("Content-Type", "application/json")
+            .json(&body)
             .header(AUTHORIZATION, format!("Bearer {}", token))
             .send()
-            .await?;
+            .await
+            .map_err(|e| CloudError::Network { source: e })?;
 
-        let status = response.status();
-        let body = response.text().await?;
+        let status = response.status().as_u16();
+        let text = response.text().await.map_err(|e| CloudError::Network { source: e })?;
+        if status >= 400 {
+            return Err(map_bigquery_http_error(status, &text));
+        }
 
-        Ok(json!({ "status": status.as_u16(), "body": body }))
+        Ok(json!({ "status": status, "body": text }))
     }
 
     pub async fn delete_table(
         &self,
         dataset_id: &str,
         table_id: &str,
-    ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
-        let url = format!(
-            "{}/projects/{}/datasets/{}/tables/{}",
-            self.base_url, self.project_id, dataset_id, table_id
+    ) -> Result<serde_json::Value, CloudError> {
+        let url = bigquery_url(
+            &self.project_id,
+            &format!("datasets/{}/tables/{}", dataset_id, table_id),
         );
+        let token = self.get_token().await?;
 
-        let token = retrieve_token().await?;
         let response = self
             .client
             .delete(&url)
-            .header("Content-Type", "application/json")
             .header(AUTHORIZATION, format!("Bearer {}", token))
             .send()
-            .await?;
+            .await
+            .map_err(|e| CloudError::Network { source: e })?;
 
-        let status = response.status();
-        let body = response.text().await?;
+        let status = response.status().as_u16();
+        let text = response.text().await.map_err(|e| CloudError::Network { source: e })?;
+        if status >= 400 {
+            return Err(map_bigquery_http_error(status, &text));
+        }
 
-        Ok(json!({ "status": status.as_u16(), "body": body }))
+        Ok(json!({ "status": status, "body": text }))
     }
 
-    pub async fn list_tables(
-        &self,
-        dataset_id: &str,
-    ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
-        let url = format!(
-            "{}/projects/{}/datasets/{}/tables",
-            self.base_url, self.project_id, dataset_id
-        );
+    pub async fn list_tables(&self, dataset_id: &str) -> Result<serde_json::Value, CloudError> {
+        let url = bigquery_url(&self.project_id, &format!("datasets/{}/tables", dataset_id));
+        let token = self.get_token().await?;
 
-        let token = retrieve_token().await?;
         let response = self
             .client
             .get(&url)
-            .header("Content-Type", "application/json")
             .header(AUTHORIZATION, format!("Bearer {}", token))
             .send()
-            .await?;
+            .await
+            .map_err(|e| CloudError::Network { source: e })?;
 
-        let status = response.status();
-        let body = response.text().await?;
+        let status = response.status().as_u16();
+        let text = response.text().await.map_err(|e| CloudError::Network { source: e })?;
+        if status >= 400 {
+            return Err(map_bigquery_http_error(status, &text));
+        }
 
-        Ok(json!({ "status": status.as_u16(), "body": body }))
+        Ok(json!({ "status": status, "body": text }))
     }
 
-    pub async fn run_query(
-        &self,
-        query: &str,
-    ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
-        let url = format!("{}/projects/{}/queries", self.base_url, self.project_id);
-
-        let body = to_string(&RunQuery {
+    pub async fn run_query(&self, query: &str) -> Result<serde_json::Value, CloudError> {
+        let url = bigquery_url(&self.project_id, "queries");
+        let body = RunQuery {
             query: query.to_string(),
             use_legacy_sql: false,
-        })?;
+        };
+        let token = self.get_token().await?;
 
-        let token = retrieve_token().await?;
         let response = self
             .client
             .post(&url)
-            .body(body)
-            .header("Content-Type", "application/json")
+            .json(&body)
             .header(AUTHORIZATION, format!("Bearer {}", token))
             .send()
-            .await?;
+            .await
+            .map_err(|e| CloudError::Network { source: e })?;
 
-        let status = response.status();
-        let body = response.text().await?;
+        let status = response.status().as_u16();
+        let text = response.text().await.map_err(|e| CloudError::Network { source: e })?;
+        if status >= 400 {
+            return Err(map_bigquery_http_error(status, &text));
+        }
 
-        Ok(json!({ "status": status.as_u16(), "body": body }))
+        Ok(json!({ "status": status, "body": text }))
+    }
+}
+
+pub(crate) fn bigquery_url(project_id: &str, path: &str) -> String {
+    format!("https://bigquery.googleapis.com/bigquery/v2/projects/{}/{}", project_id, path)
+}
+
+pub(crate) fn map_bigquery_http_error(status: u16, body: &str) -> CloudError {
+    match status {
+        401 | 403 => CloudError::Auth { message: body.to_string() },
+        404 | 409 => CloudError::Provider {
+            http_status: status,
+            message: body.to_string(),
+            retryable: false,
+        },
+        429 => CloudError::RateLimit { retry_after: None },
+        500 | 503 => CloudError::Provider {
+            http_status: status,
+            message: body.to_string(),
+            retryable: true,
+        },
+        _ => CloudError::Provider {
+            http_status: status,
+            message: body.to_string(),
+            retryable: status >= 500,
+        },
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+    use crate::gcp::gcp_apis::auth::gcp_auth::MockTokenProvider;
+
+    fn no_creds_bigquery() -> BigQuery {
+        BigQuery::with_http_client(
+            Client::new(),
+            "test-project",
+            Arc::new(MockTokenProvider::new("test-token")),
+        )
+    }
+
+    #[test]
+    fn test_bigquery_url_simple_path() {
+        assert_eq!(
+            bigquery_url("my-project", "datasets"),
+            "https://bigquery.googleapis.com/bigquery/v2/projects/my-project/datasets"
+        );
+    }
+
+    #[test]
+    fn test_bigquery_url_nested_path() {
+        assert_eq!(
+            bigquery_url("my-project", "datasets/ds1/tables/tbl1"),
+            "https://bigquery.googleapis.com/bigquery/v2/projects/my-project/datasets/ds1/tables/tbl1"
+        );
+    }
+
+    #[test]
+    fn test_map_bigquery_http_error_auth() {
+        match map_bigquery_http_error(401, "denied") {
+            CloudError::Auth { message } => assert_eq!(message, "denied"),
+            _ => panic!("expected Auth variant"),
+        }
+        match map_bigquery_http_error(403, "forbidden") {
+            CloudError::Auth { .. } => {}
+            _ => panic!("expected Auth variant"),
+        }
+    }
+
+    #[test]
+    fn test_map_bigquery_http_error_not_found_not_retryable() {
+        match map_bigquery_http_error(404, "missing") {
+            CloudError::Provider { http_status, retryable, .. } => {
+                assert_eq!(http_status, 404);
+                assert!(!retryable);
+            }
+            _ => panic!("expected Provider variant"),
+        }
+        match map_bigquery_http_error(409, "conflict") {
+            CloudError::Provider { retryable, .. } => assert!(!retryable),
+            _ => panic!("expected Provider variant"),
+        }
+    }
+
+    #[test]
+    fn test_map_bigquery_http_error_rate_limit() {
+        match map_bigquery_http_error(429, "slow down") {
+            CloudError::RateLimit { retry_after } => assert_eq!(retry_after, None),
+            _ => panic!("expected RateLimit variant"),
+        }
+    }
+
+    #[test]
+    fn test_map_bigquery_http_error_server_error_retryable() {
+        match map_bigquery_http_error(500, "boom") {
+            CloudError::Provider { retryable, .. } => assert!(retryable),
+            _ => panic!("expected Provider variant"),
+        }
+        match map_bigquery_http_error(503, "unavailable") {
+            CloudError::Provider { retryable, .. } => assert!(retryable),
+            _ => panic!("expected Provider variant"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_token_refreshes_when_expired() {
+        let bq = no_creds_bigquery();
+        let token = bq.get_token().await.unwrap();
+        assert_eq!(token, "test-token");
     }
 }

--- a/rustcloud/src/tests/gcp_bigquery_operations.rs
+++ b/rustcloud/src/tests/gcp_bigquery_operations.rs
@@ -1,16 +1,16 @@
 use crate::gcp::gcp_apis::database::gcp_bigquery::*;
 use crate::gcp::types::database::gcp_bigquery_types::*;
-use tokio::test;
 
 fn project_id() -> String {
     std::env::var("GCP_PROJECT_ID").unwrap_or_else(|_| "your_project_id".to_string())
 }
 
 async fn create_client() -> BigQuery {
-    BigQuery::new(&project_id())
+    BigQuery::new(&project_id()).await.unwrap()
 }
 
 #[tokio::test]
+#[ignore]
 async fn test_create_dataset() {
     let client = create_client().await;
     client.delete_dataset("test_create_ds", true).await.ok();
@@ -22,6 +22,7 @@ async fn test_create_dataset() {
 }
 
 #[tokio::test]
+#[ignore]
 async fn test_delete_dataset() {
     let client = create_client().await;
     client.create_dataset("test_delete_ds").await.ok();
@@ -32,6 +33,7 @@ async fn test_delete_dataset() {
 }
 
 #[tokio::test]
+#[ignore]
 async fn test_list_datasets() {
     let client = create_client().await;
     let result = client.list_datasets().await;
@@ -41,6 +43,7 @@ async fn test_list_datasets() {
 }
 
 #[tokio::test]
+#[ignore]
 async fn test_create_table() {
     let client = create_client().await;
     client.create_dataset("test_create_table_ds").await.ok();
@@ -64,10 +67,14 @@ async fn test_create_table() {
 }
 
 #[tokio::test]
+#[ignore]
 async fn test_delete_table() {
     let client = create_client().await;
     client.create_dataset("test_delete_table_ds").await.ok();
-    let fields = vec![TableField { name: "id".to_string(), field_type: "INTEGER".to_string() }];
+    let fields = vec![TableField {
+        name: "id".to_string(),
+        field_type: "INTEGER".to_string(),
+    }];
     client.create_table("test_delete_table_ds", "test_tbl", fields).await.ok();
     let result = client.delete_table("test_delete_table_ds", "test_tbl").await;
     client.delete_dataset("test_delete_table_ds", true).await.ok();
@@ -77,6 +84,7 @@ async fn test_delete_table() {
 }
 
 #[tokio::test]
+#[ignore]
 async fn test_list_tables() {
     let client = create_client().await;
     client.create_dataset("test_list_tables_ds").await.ok();
@@ -88,6 +96,7 @@ async fn test_list_tables() {
 }
 
 #[tokio::test]
+#[ignore]
 async fn test_run_query() {
     let client = create_client().await;
     let result = client.run_query("SELECT 1").await;


### PR DESCRIPTION
Closes #162 

Migrates `BigQuery` to return `CloudError` instead of `Box<dyn std::error::Error>`, checking the HTTP status on every response and mapping 4xx/5xx to the right variant via a new `map_bigquery_http_error` helper.

Adds `Arc<dyn TokenProvider>` injection and a `with_http_client` constructor, mirroring the pattern already used by `VertexAiProvider`, so the client can be exercised in tests without a service account file.

Moves the existing live tests behind `#[ignore]` and adds unit tests for URL building, error mapping, and token refresh.
