### PR TITLE
feat(azure-openai): add embed() and generate_with_tools() support

### DIFF
--- a/examples/azure/artificial_intelligence/azure_openai.md
+++ b/examples/azure/artificial_intelligence/azure_openai.md
@@ -1,0 +1,164 @@
+
+# rustcloud - Azure OpenAI
+
+## Configure credentials
+
+`AzureOpenAiProvider` authenticates with a static API key, not OAuth2. Set these environment variables:
+
+```sh
+export AZURE_OPENAI_ENDPOINT="https://my-resource.openai.azure.com"
+export AZURE_OPENAI_API_KEY="your-api-key"
+export AZURE_OPENAI_API_VERSION="2024-10-21"       # optional, defaults to 2024-10-21
+export AZURE_OPENAI_EMBED_DEPLOYMENT="text-embedding-3-small"  # only needed for embed()
+```
+
+## Initialize the provider
+
+```rust
+use rustcloud::azure::azure_apis::artificial_intelligence::azure_openai::AzureOpenAiProvider;
+
+fn main() {
+    let provider = AzureOpenAiProvider::new().expect("failed to load Azure OpenAI credentials");
+}
+```
+
+## Generate text
+
+```rust
+use rustcloud::azure::azure_apis::artificial_intelligence::azure_openai::AzureOpenAiProvider;
+use rustcloud::traits::llm_provider::LlmProvider;
+use rustcloud::types::llm::{LlmRequest, Message, ModelRef};
+
+#[tokio::main]
+async fn main() {
+    let provider = AzureOpenAiProvider::new().expect("failed to load Azure OpenAI credentials");
+
+    let req = LlmRequest {
+        model: ModelRef::Deployment("gpt-4o".to_string()),
+        messages: vec![Message {
+            role: "user".to_string(),
+            content: "Explain what a Rust lifetime is.".to_string(),
+        }],
+        max_tokens: Some(256),
+        temperature: Some(0.5),
+        system_prompt: Some("You are a concise technical writer.".to_string()),
+    };
+
+    let response = provider.generate(req).await.unwrap();
+    println!("{}", response.text);
+}
+```
+
+Reasoning deployments (`o1*`, `o3*`) are detected automatically: `max_tokens` is sent as `max_completion_tokens` and `temperature` is omitted, since those models reject it.
+
+## Stream a response
+
+```rust
+use futures::StreamExt;
+use rustcloud::azure::azure_apis::artificial_intelligence::azure_openai::AzureOpenAiProvider;
+use rustcloud::traits::llm_provider::LlmProvider;
+use rustcloud::types::llm::{LlmRequest, LlmStreamEvent, Message, ModelRef};
+
+#[tokio::main]
+async fn main() {
+    let provider = AzureOpenAiProvider::new().expect("failed to load Azure OpenAI credentials");
+
+    let req = LlmRequest {
+        model: ModelRef::Deployment("gpt-4o".to_string()),
+        messages: vec![Message {
+            role: "user".to_string(),
+            content: "List five uses of Rust in production systems.".to_string(),
+        }],
+        max_tokens: Some(512),
+        temperature: None,
+        system_prompt: None,
+    };
+
+    let mut stream = provider.stream(req).await.unwrap();
+
+    while let Some(event) = stream.next().await {
+        match event {
+            LlmStreamEvent::DeltaText(chunk) => print!("{}", chunk),
+            LlmStreamEvent::Done(_) => println!(),
+            LlmStreamEvent::Error(e) => eprintln!("stream error: {:?}", e),
+            _ => {}
+        }
+    }
+}
+```
+
+Azure sends `finish_reason` and the final `usage` block as two separate SSE chunks; the stream buffers the finish event until usage arrives (or the connection closes) so `Usage` is always emitted before `Done`.
+
+## Embed text
+
+```rust
+use rustcloud::azure::azure_apis::artificial_intelligence::azure_openai::AzureOpenAiProvider;
+use rustcloud::traits::llm_provider::LlmProvider;
+
+#[tokio::main]
+async fn main() {
+    let provider = AzureOpenAiProvider::new().expect("failed to load Azure OpenAI credentials");
+
+    let response = provider
+        .embed(vec!["The quick brown fox".to_string()])
+        .await
+        .unwrap();
+
+    println!("dimensions: {}", response.embeddings[0].len());
+}
+```
+
+Embeddings use the deployment named by `AZURE_OPENAI_EMBED_DEPLOYMENT`, separate from the chat deployment. Passing an empty slice returns immediately without a network request.
+
+## Call tools
+
+```rust
+use rustcloud::azure::azure_apis::artificial_intelligence::azure_openai::AzureOpenAiProvider;
+use rustcloud::traits::llm_provider::LlmProvider;
+use rustcloud::types::llm::{LlmRequest, Message, ModelRef, ToolCallResponse, ToolDefinition};
+
+#[tokio::main]
+async fn main() {
+    let provider = AzureOpenAiProvider::new().expect("failed to load Azure OpenAI credentials");
+
+    let tools = vec![ToolDefinition {
+        name: "get_weather".to_string(),
+        description: "Returns the current weather for a given city.".to_string(),
+        parameters: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "city": { "type": "string", "description": "City name" }
+            },
+            "required": ["city"]
+        }),
+    }];
+
+    let req = LlmRequest {
+        model: ModelRef::Deployment("gpt-4o".to_string()),
+        messages: vec![Message {
+            role: "user".to_string(),
+            content: "What is the weather in London?".to_string(),
+        }],
+        max_tokens: Some(256),
+        temperature: Some(0.0),
+        system_prompt: None,
+    };
+
+    match provider.generate_with_tools(req, tools).await.unwrap() {
+        ToolCallResponse::ToolCall { name, arguments } => {
+            println!("tool: {}, args: {}", name, arguments);
+        }
+        ToolCallResponse::Text(resp) => {
+            println!("{}", resp.text);
+        }
+    }
+}
+```
+
+`generate_with_tools` requires at least one tool; an empty list returns `CloudError::Unsupported` instead of making a request. When the model calls a tool, Azure sends its arguments as a JSON-encoded string, which is parsed back into a `serde_json::Value` before being returned.
+
+## ModelRef semantics
+
+- `ModelRef::Deployment(name)` — used as-is as the Azure deployment name. This is the native way to address an Azure OpenAI resource.
+- `ModelRef::Provider(id)` — also treated as a deployment name. Azure has no separate model registry, and users routinely name deployments after the underlying model (e.g. `gpt-4o`), so treating a provider id as a deployment alias lets model-based routing work without a second lookup.
+- `ModelRef::Logical { .. }` — returns `CloudError::Unsupported`. Azure has no generic model-family resolution API, so there's no deployment to resolve a logical model reference against.

--- a/rustcloud/src/azure/azure_apis/artificial_intelligence/azure_openai.rs
+++ b/rustcloud/src/azure/azure_apis/artificial_intelligence/azure_openai.rs
@@ -1,10 +1,12 @@
+use async_trait::async_trait;
 use futures::channel::mpsc;
 use futures::SinkExt;
 
 use crate::errors::CloudError;
-use crate::traits::llm_provider::LlmStream;
+use crate::traits::llm_provider::{LlmProvider, LlmStream};
 use crate::types::llm::{
-    FinishReason, LlmRequest, LlmResponse, LlmStreamEvent, ModelRef, UsageStats,
+    EmbedResponse, FinishReason, LlmRequest, LlmResponse, LlmStreamEvent, ModelRef,
+    ToolCallResponse, ToolDefinition, UsageStats,
 };
 
 pub struct AzureOpenAiProvider {
@@ -62,61 +64,6 @@ impl AzureOpenAiProvider {
     pub(crate) fn request(&self, url: &str) -> reqwest::RequestBuilder {
         self.client.post(url).header("api-key", self.api_key.as_str())
     }
-
-    pub async fn generate(&self, req: LlmRequest) -> Result<LlmResponse, CloudError> {
-        let deployment = extract_deployment_name(&req.model)?;
-        let url = self.azure_endpoint(&deployment, "chat/completions");
-        let body = build_chat_request(&req, &deployment);
-
-        let response = self
-            .request(&url)
-            .json(&body)
-            .send()
-            .await
-            .map_err(|e| CloudError::Network { source: e })?;
-
-        let status = response.status().as_u16();
-        if status >= 400 {
-            let text = response.text().await.unwrap_or_default();
-            return Err(map_azure_http_error(status, &text));
-        }
-
-        let bytes = response
-            .bytes()
-            .await
-            .map_err(|e| CloudError::Network { source: e })?;
-
-        let resp_json: serde_json::Value =
-            serde_json::from_slice(&bytes).map_err(|e| CloudError::Serialization { source: e })?;
-
-        parse_chat_response(&resp_json)
-    }
-
-    pub async fn stream(&self, req: LlmRequest) -> Result<LlmStream, CloudError> {
-        let deployment = extract_deployment_name(&req.model)?;
-        let url = self.azure_endpoint(&deployment, "chat/completions");
-        let mut body = build_chat_request(&req, &deployment);
-        body["stream"] = serde_json::json!(true);
-        body["stream_options"] = serde_json::json!({ "include_usage": true });
-
-        let response = self
-            .request(&url)
-            .json(&body)
-            .send()
-            .await
-            .map_err(|e| CloudError::Network { source: e })?;
-
-        let status = response.status().as_u16();
-        if status >= 400 {
-            let text = response.text().await.unwrap_or_default();
-            return Err(map_azure_http_error(status, &text));
-        }
-
-        let (tx, rx) = mpsc::channel::<LlmStreamEvent>(32);
-        tokio::spawn(pump_stream(response, tx));
-
-        Ok(Box::pin(rx))
-    }
 }
 
 pub(crate) fn extract_deployment_name(model: &ModelRef) -> Result<String, CloudError> {
@@ -154,6 +101,40 @@ pub(crate) fn build_chat_request(req: &LlmRequest, deployment: &str) -> serde_js
         if let Some(temperature) = req.temperature {
             body["temperature"] = serde_json::json!(temperature);
         }
+    }
+
+    body
+}
+
+pub(crate) fn build_embed_request(texts: &[String]) -> serde_json::Value {
+    serde_json::json!({ "input": texts })
+}
+
+pub(crate) fn build_tool_request(
+    req: &LlmRequest,
+    deployment: &str,
+    tools: &[ToolDefinition],
+) -> serde_json::Value {
+    let mut body = build_chat_request(req, deployment);
+
+    if !tools.is_empty() {
+        let functions: Vec<serde_json::Value> = tools
+            .iter()
+            .map(|t| {
+                serde_json::json!({
+                    "type": "function",
+                    "function": {
+                        "name": t.name,
+                        "description": t.description,
+                        "parameters": t.parameters,
+                    }
+                })
+            })
+            .collect();
+
+        body["tools"] = serde_json::json!(functions);
+        body["tool_choice"] = serde_json::json!("auto");
+        body["parallel_tool_calls"] = serde_json::json!(false);
     }
 
     body
@@ -218,6 +199,62 @@ pub(crate) fn parse_chat_response(json: &serde_json::Value) -> Result<LlmRespons
     Ok(LlmResponse { text, finish_reason, usage })
 }
 
+pub(crate) fn parse_embed_response(json: &serde_json::Value) -> Result<EmbedResponse, CloudError> {
+    let data = json["data"].as_array().ok_or_else(|| CloudError::Provider {
+        http_status: 0,
+        message: "parse error: response contained no data".to_string(),
+        retryable: false,
+    })?;
+
+    let mut embeddings: Vec<Option<Vec<f32>>> = vec![None; data.len()];
+    for entry in data {
+        let index = entry["index"].as_u64().ok_or_else(|| CloudError::Provider {
+            http_status: 0,
+            message: "parse error: embedding entry missing index".to_string(),
+            retryable: false,
+        })? as usize;
+        let values = entry["embedding"].as_array().ok_or_else(|| CloudError::Provider {
+            http_status: 0,
+            message: "parse error: malformed embedding in response".to_string(),
+            retryable: false,
+        })?;
+        let slot = embeddings.get_mut(index).ok_or_else(|| CloudError::Provider {
+            http_status: 0,
+            message: "parse error: embedding index out of range".to_string(),
+            retryable: false,
+        })?;
+        if slot.is_some() {
+            return Err(CloudError::Provider {
+                http_status: 0,
+                message: "parse error: duplicate embedding index".to_string(),
+                retryable: false,
+            });
+        }
+        *slot = Some(values.iter().map(|v| v.as_f64().unwrap_or(0.0) as f32).collect());
+    }
+
+    let embeddings = embeddings.into_iter().map(Option::unwrap_or_default).collect();
+    Ok(EmbedResponse { embeddings })
+}
+
+pub(crate) fn parse_tool_response(json: &serde_json::Value) -> Result<ToolCallResponse, CloudError> {
+    let call = json["choices"].get(0).and_then(|c| c["message"]["tool_calls"].get(0));
+
+    let Some(call) = call else {
+        return parse_chat_response(json).map(ToolCallResponse::Text);
+    };
+
+    let name = call["function"]["name"].as_str().unwrap_or("").to_string();
+    let raw_args = call["function"]["arguments"].as_str().unwrap_or("");
+    let arguments = serde_json::from_str(raw_args).map_err(|e| CloudError::Provider {
+        http_status: 0,
+        message: format!("parse error: tool call arguments were not valid JSON: {e}"),
+        retryable: false,
+    })?;
+
+    Ok(ToolCallResponse::ToolCall { name, arguments })
+}
+
 pub(crate) fn parse_sse_line(line: &str) -> Option<serde_json::Value> {
     let data = line.strip_prefix("data: ")?;
     if data == "[DONE]" {
@@ -242,10 +279,14 @@ pub(crate) fn drain_complete_lines(buffer: &mut Vec<u8>) -> Vec<serde_json::Valu
 pub(crate) fn sse_chunk_to_events(json: &serde_json::Value) -> Vec<LlmStreamEvent> {
     let mut events = Vec::new();
 
-    if let Some(message) = json["error"]["message"].as_str() {
+    if let Some(error) = json.get("error") {
+        let message = error["message"]
+            .as_str()
+            .unwrap_or("azure returned an error with no message")
+            .to_string();
         events.push(LlmStreamEvent::Error(CloudError::Provider {
             http_status: 200,
-            message: message.to_string(),
+            message,
             retryable: false,
         }));
         return events;
@@ -348,5 +389,134 @@ pub(crate) async fn pump_stream(mut response: reqwest::Response, mut tx: mpsc::S
                 break;
             }
         }
+    }
+}
+
+#[async_trait]
+impl LlmProvider for AzureOpenAiProvider {
+    async fn generate(&self, req: LlmRequest) -> Result<LlmResponse, CloudError> {
+        let deployment = extract_deployment_name(&req.model)?;
+        let url = self.azure_endpoint(&deployment, "chat/completions");
+        let body = build_chat_request(&req, &deployment);
+
+        let response = self
+            .request(&url)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| CloudError::Network { source: e })?;
+
+        let status = response.status().as_u16();
+        if status >= 400 {
+            let text = response.text().await.unwrap_or_default();
+            return Err(map_azure_http_error(status, &text));
+        }
+
+        let bytes = response
+            .bytes()
+            .await
+            .map_err(|e| CloudError::Network { source: e })?;
+
+        let resp_json: serde_json::Value =
+            serde_json::from_slice(&bytes).map_err(|e| CloudError::Serialization { source: e })?;
+
+        parse_chat_response(&resp_json)
+    }
+
+    async fn stream(&self, req: LlmRequest) -> Result<LlmStream, CloudError> {
+        let deployment = extract_deployment_name(&req.model)?;
+        let url = self.azure_endpoint(&deployment, "chat/completions");
+        let mut body = build_chat_request(&req, &deployment);
+        body["stream"] = serde_json::json!(true);
+        body["stream_options"] = serde_json::json!({ "include_usage": true });
+
+        let response = self
+            .request(&url)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| CloudError::Network { source: e })?;
+
+        let status = response.status().as_u16();
+        if status >= 400 {
+            let text = response.text().await.unwrap_or_default();
+            return Err(map_azure_http_error(status, &text));
+        }
+
+        let (tx, rx) = mpsc::channel::<LlmStreamEvent>(32);
+        tokio::spawn(pump_stream(response, tx));
+
+        Ok(Box::pin(rx))
+    }
+
+    async fn embed(&self, texts: Vec<String>) -> Result<EmbedResponse, CloudError> {
+        if texts.is_empty() {
+            return Ok(EmbedResponse { embeddings: vec![] });
+        }
+
+        let url = self.azure_endpoint(&self.embed_deployment, "embeddings");
+        let body = build_embed_request(&texts);
+
+        let response = self
+            .request(&url)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| CloudError::Network { source: e })?;
+
+        let status = response.status().as_u16();
+        if status >= 400 {
+            let text = response.text().await.unwrap_or_default();
+            return Err(map_azure_http_error(status, &text));
+        }
+
+        let bytes = response
+            .bytes()
+            .await
+            .map_err(|e| CloudError::Network { source: e })?;
+
+        let resp_json: serde_json::Value =
+            serde_json::from_slice(&bytes).map_err(|e| CloudError::Serialization { source: e })?;
+
+        parse_embed_response(&resp_json)
+    }
+
+    async fn generate_with_tools(
+        &self,
+        req: LlmRequest,
+        tools: Vec<ToolDefinition>,
+    ) -> Result<ToolCallResponse, CloudError> {
+        if tools.is_empty() {
+            return Err(CloudError::Unsupported {
+                feature: "generate_with_tools requires at least one tool",
+            });
+        }
+
+        let deployment = extract_deployment_name(&req.model)?;
+        let url = self.azure_endpoint(&deployment, "chat/completions");
+        let body = build_tool_request(&req, &deployment, &tools);
+
+        let response = self
+            .request(&url)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| CloudError::Network { source: e })?;
+
+        let status = response.status().as_u16();
+        if status >= 400 {
+            let text = response.text().await.unwrap_or_default();
+            return Err(map_azure_http_error(status, &text));
+        }
+
+        let bytes = response
+            .bytes()
+            .await
+            .map_err(|e| CloudError::Network { source: e })?;
+
+        let resp_json: serde_json::Value =
+            serde_json::from_slice(&bytes).map_err(|e| CloudError::Serialization { source: e })?;
+
+        parse_tool_response(&resp_json)
     }
 }

--- a/rustcloud/src/azure/azure_apis/artificial_intelligence/azure_openai.rs
+++ b/rustcloud/src/azure/azure_apis/artificial_intelligence/azure_openai.rs
@@ -1,0 +1,352 @@
+use futures::channel::mpsc;
+use futures::SinkExt;
+
+use crate::errors::CloudError;
+use crate::traits::llm_provider::LlmStream;
+use crate::types::llm::{
+    FinishReason, LlmRequest, LlmResponse, LlmStreamEvent, ModelRef, UsageStats,
+};
+
+pub struct AzureOpenAiProvider {
+    client: reqwest::Client,
+    endpoint: String,
+    api_key: String,
+    api_version: String,
+    embed_deployment: String,
+}
+
+impl AzureOpenAiProvider {
+    pub fn new() -> Result<Self, CloudError> {
+        let endpoint = std::env::var("AZURE_OPENAI_ENDPOINT").map_err(|_| CloudError::Auth {
+            message: "AZURE_OPENAI_ENDPOINT not set".to_string(),
+        })?;
+        let api_key = std::env::var("AZURE_OPENAI_API_KEY").map_err(|_| CloudError::Auth {
+            message: "AZURE_OPENAI_API_KEY not set".to_string(),
+        })?;
+        let api_version = std::env::var("AZURE_OPENAI_API_VERSION")
+            .unwrap_or_else(|_| "2024-10-21".to_owned());
+        let embed_deployment = std::env::var("AZURE_OPENAI_EMBED_DEPLOYMENT").unwrap_or_default();
+
+        Ok(Self {
+            client: reqwest::Client::new(),
+            endpoint,
+            api_key,
+            api_version,
+            embed_deployment,
+        })
+    }
+
+    pub fn with_http_client(
+        client: reqwest::Client,
+        endpoint: impl Into<String>,
+        api_key: impl Into<String>,
+        api_version: impl Into<String>,
+        embed_deployment: impl Into<String>,
+    ) -> Self {
+        Self {
+            client,
+            endpoint: endpoint.into(),
+            api_key: api_key.into(),
+            api_version: api_version.into(),
+            embed_deployment: embed_deployment.into(),
+        }
+    }
+
+    pub(crate) fn azure_endpoint(&self, deployment: &str, method: &str) -> String {
+        format!(
+            "{}/openai/deployments/{}/{}?api-version={}",
+            self.endpoint.trim_end_matches('/'), deployment, method, self.api_version
+        )
+    }
+
+    pub(crate) fn request(&self, url: &str) -> reqwest::RequestBuilder {
+        self.client.post(url).header("api-key", self.api_key.as_str())
+    }
+
+    pub async fn generate(&self, req: LlmRequest) -> Result<LlmResponse, CloudError> {
+        let deployment = extract_deployment_name(&req.model)?;
+        let url = self.azure_endpoint(&deployment, "chat/completions");
+        let body = build_chat_request(&req, &deployment);
+
+        let response = self
+            .request(&url)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| CloudError::Network { source: e })?;
+
+        let status = response.status().as_u16();
+        if status >= 400 {
+            let text = response.text().await.unwrap_or_default();
+            return Err(map_azure_http_error(status, &text));
+        }
+
+        let bytes = response
+            .bytes()
+            .await
+            .map_err(|e| CloudError::Network { source: e })?;
+
+        let resp_json: serde_json::Value =
+            serde_json::from_slice(&bytes).map_err(|e| CloudError::Serialization { source: e })?;
+
+        parse_chat_response(&resp_json)
+    }
+
+    pub async fn stream(&self, req: LlmRequest) -> Result<LlmStream, CloudError> {
+        let deployment = extract_deployment_name(&req.model)?;
+        let url = self.azure_endpoint(&deployment, "chat/completions");
+        let mut body = build_chat_request(&req, &deployment);
+        body["stream"] = serde_json::json!(true);
+        body["stream_options"] = serde_json::json!({ "include_usage": true });
+
+        let response = self
+            .request(&url)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| CloudError::Network { source: e })?;
+
+        let status = response.status().as_u16();
+        if status >= 400 {
+            let text = response.text().await.unwrap_or_default();
+            return Err(map_azure_http_error(status, &text));
+        }
+
+        let (tx, rx) = mpsc::channel::<LlmStreamEvent>(32);
+        tokio::spawn(pump_stream(response, tx));
+
+        Ok(Box::pin(rx))
+    }
+}
+
+pub(crate) fn extract_deployment_name(model: &ModelRef) -> Result<String, CloudError> {
+    match model {
+        ModelRef::Deployment(name) => Ok(name.clone()),
+        ModelRef::Provider(id) => Ok(id.clone()),
+        ModelRef::Logical { .. } => Err(CloudError::Unsupported {
+            feature: "Azure OpenAI model resolution from ModelRef::Logical",
+        }),
+    }
+}
+
+pub(crate) fn is_reasoning_model(deployment: &str) -> bool {
+    let d = deployment.to_ascii_lowercase();
+    d.starts_with("o1") || d.starts_with("o3")
+}
+
+pub(crate) fn build_chat_request(req: &LlmRequest, deployment: &str) -> serde_json::Value {
+    let mut messages = Vec::with_capacity(req.messages.len() + 1);
+    if let Some(system) = &req.system_prompt {
+        messages.push(serde_json::json!({ "role": "system", "content": system }));
+    }
+    for msg in &req.messages {
+        messages.push(serde_json::json!({ "role": msg.role, "content": msg.content }));
+    }
+
+    let mut body = serde_json::json!({ "messages": messages });
+    let reasoning = is_reasoning_model(deployment);
+
+    if let Some(max_tokens) = req.max_tokens {
+        let key = if reasoning { "max_completion_tokens" } else { "max_tokens" };
+        body[key] = serde_json::json!(max_tokens);
+    }
+    if !reasoning {
+        if let Some(temperature) = req.temperature {
+            body["temperature"] = serde_json::json!(temperature);
+        }
+    }
+
+    body
+}
+
+pub(crate) fn map_azure_http_error(status: u16, body: &str) -> CloudError {
+    match status {
+        401 | 403 => CloudError::Auth { message: body.to_string() },
+        429 => CloudError::RateLimit { retry_after: None },
+        400 => CloudError::Provider {
+            http_status: 400,
+            message: body.to_string(),
+            retryable: false,
+        },
+        500 | 503 => CloudError::Provider {
+            http_status: status,
+            message: body.to_string(),
+            retryable: true,
+        },
+        _ => CloudError::Provider {
+            http_status: status,
+            message: body.to_string(),
+            retryable: status >= 500,
+        },
+    }
+}
+
+pub(crate) fn map_finish_reason(s: &str) -> FinishReason {
+    match s {
+        "stop" => FinishReason::Stop,
+        "length" => FinishReason::Length,
+        "tool_calls" => FinishReason::ToolCall,
+        other => FinishReason::Other(other.to_string()),
+    }
+}
+
+pub(crate) fn parse_chat_response(json: &serde_json::Value) -> Result<LlmResponse, CloudError> {
+    let choice = json["choices"].get(0).ok_or_else(|| CloudError::Provider {
+        http_status: 0,
+        message: "parse error: response contained no choices".to_string(),
+        retryable: false,
+    })?;
+
+    let text = choice["message"]["content"].as_str().unwrap_or("").to_string();
+
+    let finish_reason = choice["finish_reason"]
+        .as_str()
+        .map(map_finish_reason)
+        .unwrap_or(FinishReason::Other("unknown".to_string()));
+
+    let usage = match (
+        json["usage"]["prompt_tokens"].as_u64(),
+        json["usage"]["completion_tokens"].as_u64(),
+    ) {
+        (Some(p), Some(c)) => Some(UsageStats {
+            prompt_tokens: p as u32,
+            completion_tokens: c as u32,
+        }),
+        _ => None,
+    };
+
+    Ok(LlmResponse { text, finish_reason, usage })
+}
+
+pub(crate) fn parse_sse_line(line: &str) -> Option<serde_json::Value> {
+    let data = line.strip_prefix("data: ")?;
+    if data == "[DONE]" {
+        return None;
+    }
+    serde_json::from_str(data).ok()
+}
+
+pub(crate) fn drain_complete_lines(buffer: &mut Vec<u8>) -> Vec<serde_json::Value> {
+    let mut parsed = Vec::new();
+    while let Some(pos) = buffer.iter().position(|&b| b == b'\n') {
+        let line_bytes: Vec<u8> = buffer.drain(..=pos).collect();
+        let line = String::from_utf8_lossy(&line_bytes);
+        let line = line.trim_end_matches('\n').trim_end_matches('\r');
+        if let Some(json) = parse_sse_line(line) {
+            parsed.push(json);
+        }
+    }
+    parsed
+}
+
+pub(crate) fn sse_chunk_to_events(json: &serde_json::Value) -> Vec<LlmStreamEvent> {
+    let mut events = Vec::new();
+
+    if let Some(message) = json["error"]["message"].as_str() {
+        events.push(LlmStreamEvent::Error(CloudError::Provider {
+            http_status: 200,
+            message: message.to_string(),
+            retryable: false,
+        }));
+        return events;
+    }
+
+    let choice = json["choices"].get(0);
+
+    if let Some(text) = choice.and_then(|c| c["delta"]["content"].as_str()) {
+        if !text.is_empty() {
+            events.push(LlmStreamEvent::DeltaText(text.to_string()));
+        }
+    }
+
+    if let (Some(p), Some(c)) = (
+        json["usage"]["prompt_tokens"].as_u64(),
+        json["usage"]["completion_tokens"].as_u64(),
+    ) {
+        events.push(LlmStreamEvent::Usage(UsageStats {
+            prompt_tokens: p as u32,
+            completion_tokens: c as u32,
+        }));
+    }
+
+    if let Some(reason) = choice.and_then(|c| c["finish_reason"].as_str()) {
+        events.push(LlmStreamEvent::Done(map_finish_reason(reason)));
+    }
+
+    events
+}
+
+async fn emit_chunk_events(
+    events: Vec<LlmStreamEvent>,
+    pending_done: &mut Option<LlmStreamEvent>,
+    tx: &mut mpsc::Sender<LlmStreamEvent>,
+) -> bool {
+    let has_usage = events.iter().any(|e| matches!(e, LlmStreamEvent::Usage(_)));
+
+    if !has_usage {
+        if let Some(done) = pending_done.take() {
+            if tx.send(done).await.is_err() {
+                return false;
+            }
+        }
+    }
+
+    for event in events {
+        match event {
+            LlmStreamEvent::Done(_) => *pending_done = Some(event),
+            other => {
+                if tx.send(other).await.is_err() {
+                    return false;
+                }
+            }
+        }
+    }
+
+    if has_usage {
+        if let Some(done) = pending_done.take() {
+            if tx.send(done).await.is_err() {
+                return false;
+            }
+        }
+    }
+
+    true
+}
+
+pub(crate) async fn pump_stream(mut response: reqwest::Response, mut tx: mpsc::Sender<LlmStreamEvent>) {
+    let mut buffer: Vec<u8> = Vec::new();
+    let mut pending_done: Option<LlmStreamEvent> = None;
+
+    loop {
+        match response.chunk().await {
+            Ok(Some(bytes)) => {
+                buffer.extend_from_slice(&bytes);
+                for json in drain_complete_lines(&mut buffer) {
+                    let events = sse_chunk_to_events(&json);
+                    if !emit_chunk_events(events, &mut pending_done, &mut tx).await {
+                        return;
+                    }
+                }
+            }
+            Ok(None) => {
+                if !buffer.is_empty() {
+                    buffer.push(b'\n');
+                    for json in drain_complete_lines(&mut buffer) {
+                        let events = sse_chunk_to_events(&json);
+                        if !emit_chunk_events(events, &mut pending_done, &mut tx).await {
+                            return;
+                        }
+                    }
+                }
+                if let Some(done) = pending_done.take() {
+                    let _ = tx.send(done).await;
+                }
+                break;
+            }
+            Err(e) => {
+                let _ = tx.send(LlmStreamEvent::Error(CloudError::Network { source: e })).await;
+                break;
+            }
+        }
+    }
+}

--- a/rustcloud/src/main.rs
+++ b/rustcloud/src/main.rs
@@ -17,6 +17,9 @@ pub mod azure{
         pub mod storage{
             pub mod azure_blob;
         }
+        pub mod artificial_intelligence{
+            pub mod azure_openai;
+        }
     }
 }
 pub mod aws {

--- a/rustcloud/src/tests/azure_openai_operations.rs
+++ b/rustcloud/src/tests/azure_openai_operations.rs
@@ -3,18 +3,25 @@ use futures::StreamExt;
 use crate::azure::azure_apis::artificial_intelligence::azure_openai::{
     AzureOpenAiProvider,
     build_chat_request,
+    build_embed_request,
+    build_tool_request,
     drain_complete_lines,
     extract_deployment_name,
     is_reasoning_model,
     map_azure_http_error,
     map_finish_reason,
     parse_chat_response,
+    parse_embed_response,
     parse_sse_line,
+    parse_tool_response,
     pump_stream,
     sse_chunk_to_events,
 };
 use crate::errors::CloudError;
-use crate::types::llm::{FinishReason, LlmRequest, LlmStreamEvent, Message, ModelRef};
+use crate::traits::llm_provider::LlmProvider;
+use crate::types::llm::{
+    FinishReason, LlmRequest, LlmStreamEvent, Message, ModelRef, ToolCallResponse, ToolDefinition,
+};
 
 fn no_creds_provider() -> AzureOpenAiProvider {
     AzureOpenAiProvider::with_http_client(
@@ -353,6 +360,19 @@ fn test_sse_chunk_error_object() {
     ));
 }
 
+#[test]
+fn test_sse_chunk_error_object_without_message() {
+    let json = serde_json::json!({
+        "error": { "code": "content_filter" }
+    });
+    let events = sse_chunk_to_events(&json);
+    assert_eq!(events.len(), 1);
+    assert!(matches!(
+        &events[0],
+        LlmStreamEvent::Error(CloudError::Provider { http_status: 200, .. })
+    ));
+}
+
 // --- drain_complete_lines ---
 
 #[test]
@@ -485,6 +505,256 @@ async fn test_stream_orders_usage_before_done_across_separate_chunks() {
     assert!(matches!(&events[1], LlmStreamEvent::Done(FinishReason::Stop)));
 }
 
+// --- build_embed_request ---
+
+#[test]
+fn test_build_embed_request() {
+    let texts = vec!["hello".to_string(), "world".to_string()];
+    let body = build_embed_request(&texts);
+    assert_eq!(body["input"], serde_json::json!(["hello", "world"]));
+}
+
+// --- parse_embed_response ---
+
+#[test]
+fn test_parse_embed_response_valid() {
+    let json = serde_json::json!({
+        "data": [
+            { "index": 0, "embedding": [0.1, 0.2] },
+            { "index": 1, "embedding": [0.3, 0.4] }
+        ]
+    });
+    let resp = parse_embed_response(&json).unwrap();
+    assert_eq!(resp.embeddings, vec![vec![0.1, 0.2], vec![0.3, 0.4]]);
+}
+
+#[test]
+fn test_parse_embed_response_reorders_by_index() {
+    let json = serde_json::json!({
+        "data": [
+            { "index": 1, "embedding": [0.3, 0.4] },
+            { "index": 0, "embedding": [0.1, 0.2] }
+        ]
+    });
+    let resp = parse_embed_response(&json).unwrap();
+    assert_eq!(resp.embeddings, vec![vec![0.1, 0.2], vec![0.3, 0.4]]);
+}
+
+#[test]
+fn test_parse_embed_response_missing_data_key() {
+    let json = serde_json::json!({});
+    let err = parse_embed_response(&json).unwrap_err();
+    assert!(matches!(err, CloudError::Provider { http_status: 0, .. }));
+}
+
+#[test]
+fn test_parse_embed_response_missing_index_is_error() {
+    let json = serde_json::json!({
+        "data": [
+            { "embedding": [0.1, 0.2] },
+            { "index": 1, "embedding": [0.3, 0.4] }
+        ]
+    });
+    let err = parse_embed_response(&json).unwrap_err();
+    assert!(matches!(err, CloudError::Provider { http_status: 0, .. }));
+}
+
+#[test]
+fn test_parse_embed_response_duplicate_index_is_error() {
+    let json = serde_json::json!({
+        "data": [
+            { "index": 0, "embedding": [0.1, 0.2] },
+            { "index": 0, "embedding": [0.3, 0.4] }
+        ]
+    });
+    let err = parse_embed_response(&json).unwrap_err();
+    assert!(matches!(err, CloudError::Provider { http_status: 0, .. }));
+}
+
+#[test]
+fn test_parse_embed_response_out_of_range_index_is_error() {
+    let json = serde_json::json!({
+        "data": [
+            { "index": 5, "embedding": [0.1, 0.2] }
+        ]
+    });
+    let err = parse_embed_response(&json).unwrap_err();
+    assert!(matches!(err, CloudError::Provider { http_status: 0, .. }));
+}
+
+// --- embed (no live credentials) ---
+
+#[tokio::test]
+async fn test_embed_empty_input_no_http_call() {
+    let provider = no_creds_provider();
+    let resp = provider.embed(vec![]).await.unwrap();
+    assert!(resp.embeddings.is_empty());
+}
+
+// --- build_tool_request ---
+
+fn make_tool() -> ToolDefinition {
+    ToolDefinition {
+        name: "get_weather".to_string(),
+        description: "Gets the weather for a city".to_string(),
+        parameters: serde_json::json!({
+            "type": "object",
+            "properties": { "city": { "type": "string" } },
+            "required": ["city"]
+        }),
+    }
+}
+
+#[test]
+fn test_build_tool_request_shape() {
+    let req = make_request(
+        ModelRef::Deployment("gpt-4o".to_string()),
+        vec![Message { role: "user".to_string(), content: "weather in Pune?".to_string() }],
+    );
+    let body = build_tool_request(&req, "gpt-4o", &[make_tool()]);
+
+    assert_eq!(body["tool_choice"], "auto");
+    assert_eq!(body["tools"][0]["type"], "function");
+    assert_eq!(body["tools"][0]["function"]["name"], "get_weather");
+    assert_eq!(
+        body["tools"][0]["function"]["description"],
+        "Gets the weather for a city"
+    );
+    assert_eq!(body["tools"][0]["function"]["parameters"]["type"], "object");
+}
+
+#[test]
+fn test_build_tool_request_disables_parallel_tool_calls() {
+    let req = make_request(
+        ModelRef::Deployment("gpt-4o".to_string()),
+        vec![Message { role: "user".to_string(), content: "weather in Pune?".to_string() }],
+    );
+    let body = build_tool_request(&req, "gpt-4o", &[make_tool()]);
+    assert_eq!(body["parallel_tool_calls"], false);
+}
+
+#[test]
+fn test_build_tool_request_empty_tools_omits_key() {
+    let req = make_request(
+        ModelRef::Deployment("gpt-4o".to_string()),
+        vec![Message { role: "user".to_string(), content: "hi".to_string() }],
+    );
+    let body = build_tool_request(&req, "gpt-4o", &[]);
+    assert!(body["tools"].is_null());
+    assert!(body["tool_choice"].is_null());
+}
+
+#[test]
+fn test_build_tool_request_preserves_chat_fields() {
+    let mut req = make_request(
+        ModelRef::Deployment("gpt-4o".to_string()),
+        vec![Message { role: "user".to_string(), content: "weather in Pune?".to_string() }],
+    );
+    req.max_tokens = Some(128);
+    req.system_prompt = Some("You are terse.".to_string());
+    let body = build_tool_request(&req, "gpt-4o", &[make_tool()]);
+
+    assert_eq!(body["max_tokens"], 128);
+    assert_eq!(body["messages"][0]["role"], "system");
+    assert_eq!(body["messages"][1]["content"], "weather in Pune?");
+}
+
+// --- parse_tool_response ---
+
+#[test]
+fn test_parse_tool_response_parses_stringified_arguments() {
+    let json = serde_json::json!({
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "tool_calls": [{
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": "{\"city\":\"Pune\"}"
+                    }
+                }]
+            },
+            "finish_reason": "tool_calls"
+        }]
+    });
+    let resp = parse_tool_response(&json).unwrap();
+    match resp {
+        ToolCallResponse::ToolCall { name, arguments } => {
+            assert_eq!(name, "get_weather");
+            assert_eq!(arguments["city"], "Pune");
+        }
+        other => panic!("expected ToolCall, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_parse_tool_response_malformed_arguments_string() {
+    let json = serde_json::json!({
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "tool_calls": [{
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": "not-json"
+                    }
+                }]
+            },
+            "finish_reason": "tool_calls"
+        }]
+    });
+    let err = parse_tool_response(&json).unwrap_err();
+    assert!(matches!(err, CloudError::Provider { http_status: 0, .. }));
+}
+
+#[test]
+fn test_parse_tool_response_text_fallback() {
+    let json = serde_json::json!({
+        "choices": [{
+            "message": { "role": "assistant", "content": "It's sunny." },
+            "finish_reason": "stop"
+        }]
+    });
+    let resp = parse_tool_response(&json).unwrap();
+    match resp {
+        ToolCallResponse::Text(inner) => assert_eq!(inner.text, "It's sunny."),
+        other => panic!("expected Text, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_tool_call_undefined_tool() {
+    let json = serde_json::json!({
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "tool_calls": [{
+                    "function": {
+                        "name": "some_tool_not_in_request",
+                        "arguments": "{}"
+                    }
+                }]
+            },
+            "finish_reason": "tool_calls"
+        }]
+    });
+    let resp = parse_tool_response(&json).unwrap();
+    assert!(matches!(resp, ToolCallResponse::ToolCall { name, .. } if name == "some_tool_not_in_request"));
+}
+
+// --- generate_with_tools (no live credentials) ---
+
+#[tokio::test]
+async fn test_generate_with_tools_rejects_empty_tools() {
+    let provider = no_creds_provider();
+    let req = make_request(
+        ModelRef::Deployment("gpt-4o".to_string()),
+        vec![Message { role: "user".to_string(), content: "hi".to_string() }],
+    );
+    let err = provider.generate_with_tools(req, vec![]).await.unwrap_err();
+    assert!(matches!(err, CloudError::Unsupported { .. }));
+}
+
 // --- integration tests (require live Azure OpenAI credentials, run with --ignored) ---
 
 #[tokio::test]
@@ -523,4 +793,46 @@ async fn test_stream_live() {
         }
     }
     assert!(got_text);
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_embed_live() {
+    let provider = AzureOpenAiProvider::new().expect("failed to create provider");
+    let resp = provider
+        .embed(vec!["hello world".to_string()])
+        .await
+        .expect("embed failed");
+    assert_eq!(resp.embeddings.len(), 1);
+    assert!(!resp.embeddings[0].is_empty());
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_generate_with_tools_live() {
+    let provider = AzureOpenAiProvider::new().expect("failed to create provider");
+    let req = LlmRequest {
+        model: ModelRef::Deployment("gpt-4o".to_string()),
+        messages: vec![Message {
+            role: "user".to_string(),
+            content: "What's the weather in Pune?".to_string(),
+        }],
+        max_tokens: Some(64),
+        temperature: Some(0.0),
+        system_prompt: None,
+    };
+    let tools = vec![ToolDefinition {
+        name: "get_weather".to_string(),
+        description: "Gets the weather for a city".to_string(),
+        parameters: serde_json::json!({
+            "type": "object",
+            "properties": { "city": { "type": "string" } },
+            "required": ["city"]
+        }),
+    }];
+    let resp = provider
+        .generate_with_tools(req, tools)
+        .await
+        .expect("generate_with_tools failed");
+    assert!(matches!(resp, ToolCallResponse::ToolCall { .. }));
 }

--- a/rustcloud/src/tests/azure_openai_operations.rs
+++ b/rustcloud/src/tests/azure_openai_operations.rs
@@ -1,0 +1,526 @@
+use futures::StreamExt;
+
+use crate::azure::azure_apis::artificial_intelligence::azure_openai::{
+    AzureOpenAiProvider,
+    build_chat_request,
+    drain_complete_lines,
+    extract_deployment_name,
+    is_reasoning_model,
+    map_azure_http_error,
+    map_finish_reason,
+    parse_chat_response,
+    parse_sse_line,
+    pump_stream,
+    sse_chunk_to_events,
+};
+use crate::errors::CloudError;
+use crate::types::llm::{FinishReason, LlmRequest, LlmStreamEvent, Message, ModelRef};
+
+fn no_creds_provider() -> AzureOpenAiProvider {
+    AzureOpenAiProvider::with_http_client(
+        reqwest::Client::new(),
+        "https://my-resource.openai.azure.com",
+        "fake-key",
+        "2024-10-21",
+        "",
+    )
+}
+
+fn make_request(model: ModelRef, messages: Vec<Message>) -> LlmRequest {
+    LlmRequest {
+        model,
+        messages,
+        max_tokens: None,
+        temperature: None,
+        system_prompt: None,
+    }
+}
+
+// --- azure_endpoint ---
+
+#[test]
+fn test_azure_endpoint_format() {
+    let provider = no_creds_provider();
+    let url = provider.azure_endpoint("gpt-4o", "chat/completions");
+    assert_eq!(
+        url,
+        "https://my-resource.openai.azure.com/openai/deployments/gpt-4o/chat/completions?api-version=2024-10-21"
+    );
+}
+
+#[test]
+fn test_azure_endpoint_trims_trailing_slash() {
+    let provider = AzureOpenAiProvider::with_http_client(
+        reqwest::Client::new(),
+        "https://my-resource.openai.azure.com/",
+        "fake-key",
+        "2024-10-21",
+        "",
+    );
+    let url = provider.azure_endpoint("gpt-4o", "chat/completions");
+    assert_eq!(
+        url,
+        "https://my-resource.openai.azure.com/openai/deployments/gpt-4o/chat/completions?api-version=2024-10-21"
+    );
+}
+
+// --- extract_deployment_name ---
+
+#[test]
+fn test_extract_deployment_name_from_deployment() {
+    let result = extract_deployment_name(&ModelRef::Deployment("gpt-4o-mini".to_string()));
+    assert_eq!(result.unwrap(), "gpt-4o-mini");
+}
+
+#[test]
+fn test_extract_deployment_name_provider_alias() {
+    let result = extract_deployment_name(&ModelRef::Provider("gpt-4o".to_string()));
+    assert_eq!(result.unwrap(), "gpt-4o");
+}
+
+#[test]
+fn test_extract_deployment_name_rejects_logical() {
+    let err = extract_deployment_name(&ModelRef::Logical {
+        family: "gpt".to_string(),
+        tier: Some("4o".to_string()),
+    })
+    .unwrap_err();
+    assert!(
+        matches!(err, CloudError::Unsupported { .. }),
+        "expected Unsupported, got {:?}",
+        err
+    );
+}
+
+// --- build_chat_request ---
+
+#[test]
+fn test_build_chat_request_includes_system_message() {
+    let mut req = make_request(
+        ModelRef::Deployment("gpt-4o".to_string()),
+        vec![Message { role: "user".to_string(), content: "hi".to_string() }],
+    );
+    req.system_prompt = Some("You are a helpful assistant.".to_string());
+    let body = build_chat_request(&req, "gpt-4o");
+    assert_eq!(body["messages"][0]["role"], "system");
+    assert_eq!(body["messages"][0]["content"], "You are a helpful assistant.");
+    assert_eq!(body["messages"][1]["role"], "user");
+    assert_eq!(body["messages"][1]["content"], "hi");
+}
+
+#[test]
+fn test_build_chat_request_omits_unset_params() {
+    let req = make_request(
+        ModelRef::Deployment("gpt-4o".to_string()),
+        vec![Message { role: "user".to_string(), content: "hi".to_string() }],
+    );
+    let body = build_chat_request(&req, "gpt-4o");
+    assert!(body["max_tokens"].is_null());
+    assert!(body["temperature"].is_null());
+    assert_eq!(body["messages"][0]["role"], "user");
+}
+
+#[test]
+fn test_is_reasoning_model_o1_o3() {
+    assert!(is_reasoning_model("o1-mini"));
+    assert!(is_reasoning_model("o3"));
+    assert!(is_reasoning_model("O1-PREVIEW"));
+    assert!(!is_reasoning_model("gpt-4o"));
+    assert!(!is_reasoning_model("gpt-35-turbo"));
+}
+
+#[test]
+fn test_build_chat_request_reasoning_model_uses_max_completion_tokens() {
+    let mut req = make_request(
+        ModelRef::Deployment("o1-mini".to_string()),
+        vec![Message { role: "user".to_string(), content: "hi".to_string() }],
+    );
+    req.max_tokens = Some(256);
+    let body = build_chat_request(&req, "o1-mini");
+    assert!(body["max_tokens"].is_null());
+    assert_eq!(body["max_completion_tokens"], 256);
+}
+
+#[test]
+fn test_build_chat_request_reasoning_model_omits_temperature() {
+    let mut req = make_request(
+        ModelRef::Deployment("o1-mini".to_string()),
+        vec![Message { role: "user".to_string(), content: "hi".to_string() }],
+    );
+    req.temperature = Some(0.7);
+    let body = build_chat_request(&req, "o1-mini");
+    assert!(body["temperature"].is_null());
+}
+
+// --- map_finish_reason ---
+
+#[test]
+fn test_map_finish_reason_stop() {
+    assert!(matches!(map_finish_reason("stop"), FinishReason::Stop));
+}
+
+#[test]
+fn test_map_finish_reason_length() {
+    assert!(matches!(map_finish_reason("length"), FinishReason::Length));
+}
+
+#[test]
+fn test_map_finish_reason_tool_calls() {
+    assert!(matches!(map_finish_reason("tool_calls"), FinishReason::ToolCall));
+}
+
+#[test]
+fn test_map_finish_reason_other() {
+    let r = map_finish_reason("content_filter");
+    assert!(matches!(r, FinishReason::Other(s) if s == "content_filter"));
+}
+
+// --- parse_chat_response ---
+
+#[test]
+fn test_parse_chat_response_valid() {
+    let json = serde_json::json!({
+        "choices": [{
+            "message": { "role": "assistant", "content": "Hello!" },
+            "finish_reason": "stop"
+        }],
+        "usage": { "prompt_tokens": 5, "completion_tokens": 2 }
+    });
+    let resp = parse_chat_response(&json).unwrap();
+    assert_eq!(resp.text, "Hello!");
+    assert!(matches!(resp.finish_reason, FinishReason::Stop));
+    let usage = resp.usage.unwrap();
+    assert_eq!(usage.prompt_tokens, 5);
+    assert_eq!(usage.completion_tokens, 2);
+}
+
+#[test]
+fn test_parse_chat_response_missing_choices() {
+    let json = serde_json::json!({ "choices": [] });
+    let err = parse_chat_response(&json).unwrap_err();
+    assert!(
+        matches!(err, CloudError::Provider { http_status: 0, .. }),
+        "expected parse-error Provider variant, got {:?}",
+        err
+    );
+}
+
+#[test]
+fn test_parse_chat_response_no_usage() {
+    let json = serde_json::json!({
+        "choices": [{
+            "message": { "role": "assistant", "content": "ok" },
+            "finish_reason": "stop"
+        }]
+    });
+    let resp = parse_chat_response(&json).unwrap();
+    assert!(resp.usage.is_none());
+}
+
+// --- map_azure_http_error ---
+
+#[test]
+fn test_map_azure_http_error_401_is_auth() {
+    assert!(matches!(map_azure_http_error(401, "unauthorized"), CloudError::Auth { .. }));
+}
+
+#[test]
+fn test_map_azure_http_error_403_is_auth() {
+    assert!(matches!(map_azure_http_error(403, "forbidden"), CloudError::Auth { .. }));
+}
+
+#[test]
+fn test_map_azure_http_error_429_is_rate_limit() {
+    assert!(matches!(map_azure_http_error(429, "quota exceeded"), CloudError::RateLimit { .. }));
+}
+
+#[test]
+fn test_map_azure_http_error_400_is_not_retryable() {
+    assert!(matches!(
+        map_azure_http_error(400, "bad request"),
+        CloudError::Provider { retryable: false, .. }
+    ));
+}
+
+#[test]
+fn test_map_azure_http_error_500_is_retryable() {
+    assert!(matches!(
+        map_azure_http_error(500, "internal error"),
+        CloudError::Provider { retryable: true, .. }
+    ));
+}
+
+#[test]
+fn test_map_azure_http_error_503_is_retryable() {
+    assert!(matches!(
+        map_azure_http_error(503, "unavailable"),
+        CloudError::Provider { retryable: true, .. }
+    ));
+}
+
+#[test]
+fn test_map_azure_http_error_404_wildcard_not_retryable() {
+    assert!(matches!(
+        map_azure_http_error(404, "not found"),
+        CloudError::Provider { retryable: false, .. }
+    ));
+}
+
+// --- parse_sse_line ---
+
+#[test]
+fn test_parse_sse_line_data_prefix() {
+    let json = parse_sse_line(r#"data: {"choices": []}"#);
+    assert!(json.is_some());
+    assert_eq!(json.unwrap()["choices"], serde_json::json!([]));
+}
+
+#[test]
+fn test_parse_sse_line_done_terminator() {
+    assert!(parse_sse_line("data: [DONE]").is_none());
+}
+
+#[test]
+fn test_parse_sse_line_non_data() {
+    assert!(parse_sse_line(": keep-alive").is_none());
+}
+
+#[test]
+fn test_parse_sse_line_invalid_json() {
+    assert!(parse_sse_line("data: not-json").is_none());
+}
+
+#[test]
+fn test_parse_sse_line_blank_line() {
+    assert!(parse_sse_line("").is_none());
+}
+
+// --- sse_chunk_to_events ---
+
+#[test]
+fn test_sse_chunk_delta_text() {
+    let json = serde_json::json!({
+        "choices": [{ "delta": { "content": "Hello" }, "finish_reason": null }]
+    });
+    let events = sse_chunk_to_events(&json);
+    assert_eq!(events.len(), 1);
+    assert!(matches!(&events[0], LlmStreamEvent::DeltaText(t) if t == "Hello"));
+}
+
+#[test]
+fn test_sse_chunk_finish_reason() {
+    let json = serde_json::json!({
+        "choices": [{ "delta": {}, "finish_reason": "stop" }]
+    });
+    let events = sse_chunk_to_events(&json);
+    assert_eq!(events.len(), 1);
+    assert!(matches!(&events[0], LlmStreamEvent::Done(FinishReason::Stop)));
+}
+
+#[test]
+fn test_sse_chunk_usage_only_empty_choices() {
+    let json = serde_json::json!({
+        "choices": [],
+        "usage": { "prompt_tokens": 5, "completion_tokens": 10 }
+    });
+    let events = sse_chunk_to_events(&json);
+    assert_eq!(events.len(), 1);
+    assert!(matches!(&events[0], LlmStreamEvent::Usage(u) if u.prompt_tokens == 5 && u.completion_tokens == 10));
+}
+
+#[test]
+fn test_sse_chunk_finish_emits_usage_then_done() {
+    let json = serde_json::json!({
+        "choices": [{ "delta": {}, "finish_reason": "stop" }],
+        "usage": { "prompt_tokens": 5, "completion_tokens": 10 }
+    });
+    let events = sse_chunk_to_events(&json);
+    assert_eq!(events.len(), 2);
+    assert!(matches!(&events[0], LlmStreamEvent::Usage(_)));
+    assert!(matches!(&events[1], LlmStreamEvent::Done(FinishReason::Stop)));
+}
+
+#[test]
+fn test_sse_chunk_error_object() {
+    let json = serde_json::json!({
+        "error": { "message": "content filtered", "code": "content_filter" }
+    });
+    let events = sse_chunk_to_events(&json);
+    assert_eq!(events.len(), 1);
+    assert!(matches!(
+        &events[0],
+        LlmStreamEvent::Error(CloudError::Provider { http_status: 200, .. })
+    ));
+}
+
+// --- drain_complete_lines ---
+
+#[test]
+fn test_drain_complete_lines_handles_multibyte_utf8_split_across_calls() {
+    let line = "data: {\"choices\":[{\"delta\":{\"content\":\"caf\u{e9}\"},\"finish_reason\":null}]}\n";
+    let bytes = line.as_bytes();
+    // split mid two-byte UTF-8 char
+    let split_at = bytes.iter().position(|&b| b == 0xC3).unwrap() + 1;
+
+    let mut buffer: Vec<u8> = Vec::new();
+    buffer.extend_from_slice(&bytes[..split_at]);
+    assert!(drain_complete_lines(&mut buffer).is_empty(), "no complete line yet");
+
+    buffer.extend_from_slice(&bytes[split_at..]);
+    let parsed = drain_complete_lines(&mut buffer);
+    assert_eq!(parsed.len(), 1);
+    assert_eq!(parsed[0]["choices"][0]["delta"]["content"], "café");
+}
+
+// --- pump_stream edge cases (no live credentials) ---
+
+#[tokio::test]
+async fn test_stream_connection_drop() {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        // unread request bytes on close cause an RST, not a truncated body
+        let mut discard = [0u8; 1024];
+        let _ = socket.read(&mut discard).await;
+        let _ = socket
+            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\nshort")
+            .await;
+    });
+
+    let response = reqwest::Client::new()
+        .get(format!("http://{}/", addr))
+        .send()
+        .await
+        .unwrap();
+
+    let (tx, mut rx) = futures::channel::mpsc::channel::<LlmStreamEvent>(32);
+    pump_stream(response, tx).await;
+
+    match rx.next().await {
+        Some(LlmStreamEvent::Error(CloudError::Network { .. })) => {}
+        other => panic!("expected a Network error event, got {:?}", other),
+    }
+    assert!(rx.next().await.is_none());
+}
+
+#[tokio::test]
+async fn test_stream_flushes_trailing_line_without_terminator() {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    // no trailing newline before the clean close
+    let body = r#"data: {"choices":[{"delta":{"content":"hi"},"finish_reason":null}]}"#;
+    let body_len = body.len();
+
+    tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let mut discard = [0u8; 1024];
+        let _ = socket.read(&mut discard).await;
+        let response = format!("HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}", body_len, body);
+        let _ = socket.write_all(response.as_bytes()).await;
+    });
+
+    let response = reqwest::Client::new()
+        .get(format!("http://{}/", addr))
+        .send()
+        .await
+        .unwrap();
+
+    let (tx, mut rx) = futures::channel::mpsc::channel::<LlmStreamEvent>(32);
+    pump_stream(response, tx).await;
+
+    match rx.next().await {
+        Some(LlmStreamEvent::DeltaText(t)) => assert_eq!(t, "hi"),
+        other => panic!("expected DeltaText(\"hi\"), got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn test_stream_orders_usage_before_done_across_separate_chunks() {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    // real Azure/OpenAI wire behavior: finish_reason and usage arrive as two
+    // separate chunks, not combined in one JSON payload
+    let finish_line = r#"data: {"choices":[{"delta":{},"finish_reason":"stop"}]}"#;
+    let usage_line = r#"data: {"choices":[],"usage":{"prompt_tokens":5,"completion_tokens":10}}"#;
+    let body = format!("{}\n{}\n", finish_line, usage_line);
+    let body_len = body.len();
+
+    tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let mut discard = [0u8; 1024];
+        let _ = socket.read(&mut discard).await;
+        let response = format!("HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}", body_len, body);
+        let _ = socket.write_all(response.as_bytes()).await;
+    });
+
+    let response = reqwest::Client::new()
+        .get(format!("http://{}/", addr))
+        .send()
+        .await
+        .unwrap();
+
+    let (tx, mut rx) = futures::channel::mpsc::channel::<LlmStreamEvent>(32);
+    pump_stream(response, tx).await;
+
+    let mut events = Vec::new();
+    while let Some(event) = rx.next().await {
+        events.push(event);
+    }
+
+    assert_eq!(events.len(), 2);
+    assert!(matches!(&events[0], LlmStreamEvent::Usage(u) if u.prompt_tokens == 5 && u.completion_tokens == 10));
+    assert!(matches!(&events[1], LlmStreamEvent::Done(FinishReason::Stop)));
+}
+
+// --- integration tests (require live Azure OpenAI credentials, run with --ignored) ---
+
+#[tokio::test]
+#[ignore]
+async fn test_generate_live() {
+    let provider = AzureOpenAiProvider::new().expect("failed to create provider");
+    let req = LlmRequest {
+        model: ModelRef::Deployment("gpt-4o".to_string()),
+        messages: vec![Message { role: "user".to_string(), content: "What is 2 + 2?".to_string() }],
+        max_tokens: Some(64),
+        temperature: Some(0.0),
+        system_prompt: None,
+    };
+    let resp = provider.generate(req).await.expect("generate failed");
+    assert!(!resp.text.is_empty());
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_stream_live() {
+    let provider = AzureOpenAiProvider::new().expect("failed to create provider");
+    let req = LlmRequest {
+        model: ModelRef::Deployment("gpt-4o".to_string()),
+        messages: vec![Message { role: "user".to_string(), content: "Count from 1 to 5.".to_string() }],
+        max_tokens: Some(64),
+        temperature: Some(0.0),
+        system_prompt: None,
+    };
+    let mut stream = provider.stream(req).await.expect("stream failed");
+    let mut got_text = false;
+    while let Some(event) = stream.next().await {
+        match event {
+            LlmStreamEvent::DeltaText(_) => got_text = true,
+            LlmStreamEvent::Error(e) => panic!("stream error: {:?}", e),
+            _ => {}
+        }
+    }
+    assert!(got_text);
+}

--- a/rustcloud/src/tests/mod.rs
+++ b/rustcloud/src/tests/mod.rs
@@ -1,4 +1,5 @@
 mod azure_blob_operations;
+mod azure_openai_operations;
 mod aws_archival_operations;
 mod aws_bedrock_operations;
 mod aws_block_operations;


### PR DESCRIPTION
Closes #170 

Completes `AzureOpenAiProvider`'s `LlmProvider` implementation.

**embed()**
`build_embed_request()` builds the `{"input": texts}` body. `parse_embed_response()` places each embedding by its `index` field rather than array position, since ordering isn't a documented guarantee — a missing, duplicate, or out-of-range index is now a hard `Provider` error rather than silently corrupting or dropping an embedding. Empty input short-circuits without an HTTP call, matching `VertexAiProvider::embed()`.

**generate_with_tools()**
`build_tool_request()` layers `tools` / `tool_choice: "auto"` on top of `build_chat_request()`. `parse_tool_response()` re-parses `tool_calls[0].function.arguments` from Azure's JSON-encoded string (its one deviation from Bedrock/Vertex, which return structured args). Empty tool lists are rejected upfront with `CloudError::Unsupported`, matching Bedrock's behavior. Azure defaults to `parallel_tool_calls: true`, which would make multi-call responses routine and silently drop every call past the first given `ToolCallResponse` only holds one — the request now explicitly sets `parallel_tool_calls: false` rather than changing the shared response type used by all three providers.

**Trait wiring**
With all 4 methods now implemented, `generate()` / `stream()` / `embed()` / `generate_with_tools()` moved into a single `impl LlmProvider for AzureOpenAiProvider` block at the end of the file, matching `VertexAiProvider`'s structure — deferred until now since Rust requires trait impls to be complete.

Also adds `examples/azure/artificial_intelligence/azure_openai.md`.

56 unit tests passing
