### PR TITLE
fix(azure-openai): human-readable error messages + Retry-After support

### DIFF
--- a/rustcloud/src/azure/azure_apis/artificial_intelligence/azure_openai.rs
+++ b/rustcloud/src/azure/azure_apis/artificial_intelligence/azure_openai.rs
@@ -140,25 +140,24 @@ pub(crate) fn build_tool_request(
     body
 }
 
-pub(crate) fn map_azure_http_error(status: u16, body: &str) -> CloudError {
+pub(crate) fn retry_after_seconds(headers: &reqwest::header::HeaderMap) -> Option<u64> {
+    headers.get(reqwest::header::RETRY_AFTER)?.to_str().ok()?.parse().ok()
+}
+
+pub(crate) fn parse_azure_error_message(body: &str) -> String {
+    serde_json::from_str::<serde_json::Value>(body)
+        .ok()
+        .and_then(|v| v["error"]["message"].as_str().map(str::to_owned))
+        .unwrap_or_else(|| body.trim().to_owned())
+}
+
+pub(crate) fn map_azure_http_error(status: u16, body: &str, retry_after: Option<u64>) -> CloudError {
+    let message = parse_azure_error_message(body);
     match status {
-        401 | 403 => CloudError::Auth { message: body.to_string() },
-        429 => CloudError::RateLimit { retry_after: None },
-        400 => CloudError::Provider {
-            http_status: 400,
-            message: body.to_string(),
-            retryable: false,
-        },
-        500 | 503 => CloudError::Provider {
-            http_status: status,
-            message: body.to_string(),
-            retryable: true,
-        },
-        _ => CloudError::Provider {
-            http_status: status,
-            message: body.to_string(),
-            retryable: status >= 500,
-        },
+        401 | 403 => CloudError::Auth { message },
+        429 => CloudError::RateLimit { retry_after },
+        400 => CloudError::Provider { http_status: 400, message, retryable: false },
+        _ => CloudError::Provider { http_status: status, message, retryable: status >= 500 },
     }
 }
 
@@ -354,6 +353,13 @@ async fn emit_chunk_events(
     true
 }
 
+pub(crate) async fn provider_error_from_response(response: reqwest::Response) -> CloudError {
+    let status = response.status().as_u16();
+    let retry_after = retry_after_seconds(response.headers());
+    let text = response.text().await.unwrap_or_default();
+    map_azure_http_error(status, &text, retry_after)
+}
+
 pub(crate) async fn pump_stream(mut response: reqwest::Response, mut tx: mpsc::Sender<LlmStreamEvent>) {
     let mut buffer: Vec<u8> = Vec::new();
     let mut pending_done: Option<LlmStreamEvent> = None;
@@ -406,10 +412,8 @@ impl LlmProvider for AzureOpenAiProvider {
             .await
             .map_err(|e| CloudError::Network { source: e })?;
 
-        let status = response.status().as_u16();
-        if status >= 400 {
-            let text = response.text().await.unwrap_or_default();
-            return Err(map_azure_http_error(status, &text));
+        if response.status().as_u16() >= 400 {
+            return Err(provider_error_from_response(response).await);
         }
 
         let bytes = response
@@ -437,10 +441,8 @@ impl LlmProvider for AzureOpenAiProvider {
             .await
             .map_err(|e| CloudError::Network { source: e })?;
 
-        let status = response.status().as_u16();
-        if status >= 400 {
-            let text = response.text().await.unwrap_or_default();
-            return Err(map_azure_http_error(status, &text));
+        if response.status().as_u16() >= 400 {
+            return Err(provider_error_from_response(response).await);
         }
 
         let (tx, rx) = mpsc::channel::<LlmStreamEvent>(32);
@@ -464,10 +466,8 @@ impl LlmProvider for AzureOpenAiProvider {
             .await
             .map_err(|e| CloudError::Network { source: e })?;
 
-        let status = response.status().as_u16();
-        if status >= 400 {
-            let text = response.text().await.unwrap_or_default();
-            return Err(map_azure_http_error(status, &text));
+        if response.status().as_u16() >= 400 {
+            return Err(provider_error_from_response(response).await);
         }
 
         let bytes = response
@@ -503,10 +503,8 @@ impl LlmProvider for AzureOpenAiProvider {
             .await
             .map_err(|e| CloudError::Network { source: e })?;
 
-        let status = response.status().as_u16();
-        if status >= 400 {
-            let text = response.text().await.unwrap_or_default();
-            return Err(map_azure_http_error(status, &text));
+        if response.status().as_u16() >= 400 {
+            return Err(provider_error_from_response(response).await);
         }
 
         let bytes = response

--- a/rustcloud/src/tests/azure_openai_operations.rs
+++ b/rustcloud/src/tests/azure_openai_operations.rs
@@ -10,11 +10,14 @@ use crate::azure::azure_apis::artificial_intelligence::azure_openai::{
     is_reasoning_model,
     map_azure_http_error,
     map_finish_reason,
+    parse_azure_error_message,
     parse_chat_response,
     parse_embed_response,
     parse_sse_line,
     parse_tool_response,
+    provider_error_from_response,
     pump_stream,
+    retry_after_seconds,
     sse_chunk_to_events,
 };
 use crate::errors::CloudError;
@@ -224,27 +227,79 @@ fn test_parse_chat_response_no_usage() {
     assert!(resp.usage.is_none());
 }
 
+// --- retry_after_seconds ---
+
+#[test]
+fn test_retry_after_seconds_parses_header() {
+    let mut headers = reqwest::header::HeaderMap::new();
+    headers.insert(reqwest::header::RETRY_AFTER, "30".parse().unwrap());
+    assert_eq!(retry_after_seconds(&headers), Some(30));
+}
+
+#[test]
+fn test_retry_after_seconds_absent() {
+    let headers = reqwest::header::HeaderMap::new();
+    assert_eq!(retry_after_seconds(&headers), None);
+}
+
+#[test]
+fn test_retry_after_seconds_non_numeric_returns_none() {
+    let mut headers = reqwest::header::HeaderMap::new();
+    headers.insert(reqwest::header::RETRY_AFTER, "soon".parse().unwrap());
+    assert_eq!(retry_after_seconds(&headers), None);
+}
+
+// --- parse_azure_error_message ---
+
+#[test]
+fn test_parse_azure_error_message_extracts_field() {
+    let body = r#"{"error": {"code": "invalid_request", "message": "The api-key you provided is invalid."}}"#;
+    assert_eq!(parse_azure_error_message(body), "The api-key you provided is invalid.");
+}
+
+#[test]
+fn test_parse_azure_error_message_falls_back_on_non_json() {
+    assert_eq!(parse_azure_error_message("  not json at all  "), "not json at all");
+}
+
+#[test]
+fn test_parse_azure_error_message_falls_back_on_missing_field() {
+    let body = r#"{"error": {"code": "invalid_request"}}"#;
+    assert_eq!(parse_azure_error_message(body), body);
+}
+
 // --- map_azure_http_error ---
 
 #[test]
 fn test_map_azure_http_error_401_is_auth() {
-    assert!(matches!(map_azure_http_error(401, "unauthorized"), CloudError::Auth { .. }));
+    assert!(matches!(map_azure_http_error(401, "unauthorized", None), CloudError::Auth { .. }));
 }
 
 #[test]
 fn test_map_azure_http_error_403_is_auth() {
-    assert!(matches!(map_azure_http_error(403, "forbidden"), CloudError::Auth { .. }));
+    assert!(matches!(map_azure_http_error(403, "forbidden", None), CloudError::Auth { .. }));
 }
 
 #[test]
-fn test_map_azure_http_error_429_is_rate_limit() {
-    assert!(matches!(map_azure_http_error(429, "quota exceeded"), CloudError::RateLimit { .. }));
+fn test_map_azure_http_error_429_reads_retry_after() {
+    assert!(matches!(
+        map_azure_http_error(429, "quota exceeded", Some(30)),
+        CloudError::RateLimit { retry_after: Some(30) }
+    ));
+}
+
+#[test]
+fn test_map_azure_http_error_429_none_when_header_absent() {
+    assert!(matches!(
+        map_azure_http_error(429, "quota exceeded", None),
+        CloudError::RateLimit { retry_after: None }
+    ));
 }
 
 #[test]
 fn test_map_azure_http_error_400_is_not_retryable() {
     assert!(matches!(
-        map_azure_http_error(400, "bad request"),
+        map_azure_http_error(400, "bad request", None),
         CloudError::Provider { retryable: false, .. }
     ));
 }
@@ -252,7 +307,7 @@ fn test_map_azure_http_error_400_is_not_retryable() {
 #[test]
 fn test_map_azure_http_error_500_is_retryable() {
     assert!(matches!(
-        map_azure_http_error(500, "internal error"),
+        map_azure_http_error(500, "internal error", None),
         CloudError::Provider { retryable: true, .. }
     ));
 }
@@ -260,7 +315,7 @@ fn test_map_azure_http_error_500_is_retryable() {
 #[test]
 fn test_map_azure_http_error_503_is_retryable() {
     assert!(matches!(
-        map_azure_http_error(503, "unavailable"),
+        map_azure_http_error(503, "unavailable", None),
         CloudError::Provider { retryable: true, .. }
     ));
 }
@@ -268,7 +323,7 @@ fn test_map_azure_http_error_503_is_retryable() {
 #[test]
 fn test_map_azure_http_error_404_wildcard_not_retryable() {
     assert!(matches!(
-        map_azure_http_error(404, "not found"),
+        map_azure_http_error(404, "not found", None),
         CloudError::Provider { retryable: false, .. }
     ));
 }
@@ -390,6 +445,40 @@ fn test_drain_complete_lines_handles_multibyte_utf8_split_across_calls() {
     let parsed = drain_complete_lines(&mut buffer);
     assert_eq!(parsed.len(), 1);
     assert_eq!(parsed[0]["choices"][0]["delta"]["content"], "café");
+}
+
+// --- provider_error_from_response (no live credentials) ---
+
+#[tokio::test]
+async fn test_provider_error_from_response_maps_status_and_retry_after() {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let body = r#"{"error": {"code": "429", "message": "Requests to this deployment exceeded the rate limit."}}"#;
+
+    tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let mut discard = [0u8; 1024];
+        let _ = socket.read(&mut discard).await;
+        let response = format!(
+            "HTTP/1.1 429 Too Many Requests\r\nRetry-After: 17\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let _ = socket.write_all(response.as_bytes()).await;
+    });
+
+    let response = reqwest::Client::new()
+        .get(format!("http://{}/", addr))
+        .send()
+        .await
+        .unwrap();
+
+    let err = provider_error_from_response(response).await;
+    assert!(matches!(err, CloudError::RateLimit { retry_after: Some(17) }), "got {:?}", err);
 }
 
 // --- pump_stream edge cases (no live credentials) ---


### PR DESCRIPTION
Closes #172 

Adds `parse_azure_error_message` to extract `error.message` from Azure's JSON error body, falling back to the raw trimmed body when parsing fails or the field is missing. Adds `retry_after_seconds` to read the `Retry-After` header off the response. `map_azure_http_error` now takes `retry_after: Option<u64>` and routes messages through the new parser, surfacing the real wait time on `RateLimit`. The per-call-site status/header/body handling across `generate`, `stream`, `embed`, and `generate_with_tools` is pulled into one `provider_error_from_response` helper rather than repeated four times, since all four call sites already had to change in lockstep for this PR and would only drift further on the next one.
